### PR TITLE
Add support for python 3.12 as a release candidate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,10 @@ jobs:
 #          - 'windows-latest'
         python-version:
           - '3.11'
+          - '3.12'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.11
+      - name: Set up Python ${{matrix.python-version}}
         uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,14 +42,19 @@ jobs:
     needs:
       - test
       - check_version
+    strategy:
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.11
+      - name: Set up Python ${{matrix.python-version}}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: ${{matrix.python-version}}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel build && \
@@ -144,7 +149,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          
+
   docker:
     runs-on: ubuntu-latest
     needs:

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ It uses data contract YAML files to lint the data contract, connect to data sour
 
 ## Getting started
 
-Let's use [pip](https://pip.pypa.io/en/stable/getting-started/) to install the CLI.  
+Let's use [pip](https://pip.pypa.io/en/stable/getting-started/) to install the CLI.
 ```bash
 $ pip3 install datacontract-cli
 ```
 
-Now, let's look at this data contract:  
+Now, let's look at this data contract:
 [https://datacontract.com/examples/covid-cases/datacontract.yaml](https://datacontract.com/examples/covid-cases/datacontract.yaml)
 
 We have a _servers_ section with endpoint details to the (public) S3 bucket, _models_ for the structure of the data, and _quality_ attributes that describe the expected freshness and number of rows.
@@ -95,6 +95,7 @@ Choose the most appropriate installation method for your needs:
 
 ### pip
 Python 3.11 recommended.
+Python 3.12 available as pre-release release candidate for 0.9.3
 
 ```bash
 pip3 install datacontract-cli
@@ -125,7 +126,7 @@ docker run --rm -v ${PWD}:/datacontract datacontract/cli
 
 Data Contract CLI can connect to data sources and run schema and quality tests to verify that the data contract is valid.
 
-```bash 
+```bash
 $ datacontract test --server production datacontract.yaml
 ```
 
@@ -178,7 +179,8 @@ export DATACONTRACT_S3_SECRET_ACCESS_KEY=93S7LRrJcqLkdb2/XXXXXXXXXXXXX
 
 ## Development Setup
 
-Python base interpreter should be 3.11.x
+Python base interpreter should be 3.11.x (unless
+working on 3.12 release candidate).
 
 ```bash
 # create venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datacontract-cli"
-version = "0.9.2"
+version = "0.9.3-rc.1"
 description = "Validate data contracts"
 readme = "README.md"
 authors = [
@@ -12,7 +12,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-requires-python = "~=3.11"
+requires-python = ">=3.11"
 dependencies = [
   "typer[all]~=0.9.0",
   "pydantic~=2.5.3",
@@ -23,7 +23,7 @@ dependencies = [
   "soda-core-duckdb~=3.1.5",
   "soda-core-snowflake~=3.1.5", # snowflake
   "snowflake-connector-python[pandas]~=3.6.0", # snowflake
-  "duckdb~=0.9.2",
+  "duckdb>=0.9.3.dev3920",
   "fastjsonschema~=2.19.1",
   "python-dotenv~=1.0.0",
   "s3fs==2023.12.2",


### PR DESCRIPTION
full support needs to wait until `duckdb` `0.10.0` according to their docs:

https://duckdb.org/docs/api/python/overview.html

However, their release candidates already have support for 3.12. It was added for all platforms in January (earlier they only had support for linux and mac os x).

**Modified the github actions CI as well to test CI and building it on 3.12
so you will have to review and approve a workflow run if you want to test it.**
(Hopefully I didn't mess up anything by changing the ci workflow to include 3.12, but if I did, at least
you should be able to secure the repo for the future  :smile: )

We are testing out adopting the data contract specification for a data platform and the CLI is helpful. However we already had 3.12 support on the repo where we work with the contracts so I wanted to build the cli for 3.12

All tests pass locally on python 3.12 with these changes, though there are some depreciation warnings to handle
(I think dependency updates should fix these).

Great work and let me know if this type of PR is welcome or not.

(Releasing would require pushing the version tag `0.9.3-rc.1`, although I recommend moving to the pypa standard
of `0.9.3.rcN` https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pre-release-versioning)

<details>
  <summary>My local pytest results on Python 3.12</summary>

### Pytest output
````zsh

platform linux -- Python 3.12.1, pytest-8.0.0, pluggy-1.4.0
rootdir: <REDACTED>/contract-cli/tests
collected 22 items                                                                                                                                                                                   

test_cli.py ..                                                                                                                                                                                 [  9%]
test_download_datacontract_file.py ....                                                                                                                                                        [ 27%]
test_example_parquet.py ..                                                                                                                                                                     [ 36%]
test_examples_local_json.py ..                                                                                                                                                                 [ 45%]
test_examples_s3_csv.py .                                                                                                                                                                      [ 50%]
test_examples_s3_json.py .                                                                                                                                                                     [ 54%]
test_examples_s3_json_complex.py .                                                                                                                                                             [ 59%]
test_examples_s3_json_remote.py .                                                                                                                                                              [ 63%]
test_export_jsonschema.py ...                                                                                                                                                                  [ 77%]
test_export_sodacl.py .                                                                                                                                                                        [ 81%]
test_lint.py ....                                                                                                                                                                              [100%]

 warnings summary 

REDACTED/envs/contract-cli/lib/python3.12/site-packages/dateutil/tz/tz.py:37
 REDACTED/envs/contract-cli/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

test_examples_s3_json.py::test_examples_s3_json
test_examples_s3_json.py::test_examples_s3_json
test_examples_s3_json.py::test_examples_s3_json
test_examples_s3_json_complex.py::test_examples_s3_json
test_examples_s3_json_complex.py::test_examples_s3_json
 REDACTED/envs/contract-cli/lib/python3.12/site-packages/botocore/auth.py:419: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    datetime_now = datetime.datetime.utcnow()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
22 passed, 8 warnings in 29.69s 
```
</details>