### PR TITLE
Fix reading file from local server

### DIFF
--- a/datacontract/engines/fastjsonschema/check_jsonschema.py
+++ b/datacontract/engines/fastjsonschema/check_jsonschema.py
@@ -46,7 +46,7 @@ def read_json_array(file):
 
 
 def read_json_file(file):
-    yield json.loads(file)
+    yield json.loads(file.read())
 
 
 def process_json_file(run, model_name, validate, file, delimiter):


### PR DESCRIPTION
I've faced the following error when trying to execute `datacontract test datacontract.yaml` with a local fileserver. 
```
  File "/usr/local/anaconda3/lib/python3.11/site-packages/datacontract/engines/fastjsonschema/check_jsonschema.py", line 49, in read_json_file
    yield json.loads(file)
          ^^^^^^^^^^^^^^^^

TypeError: the JSON object must be str, bytes or bytearray, not TextIOWrapper
```

Configuration in datacontract.yaml:
```
servers:
  server_local_test:
    type: local
    path: "myfile.json"
    format: json
```