### PR TITLE
add rdf convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - export to ODCS (#49).
 - test - show a test summary table.
 - lint - Support local schema (#46).
+- convert to rdf (#52)
 
 ## [0.9.4] - 2024-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- export to rdf (#52)
 
 ## [0.9.5] - 2024-02-22
 
@@ -14,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - export to ODCS (#49).
 - test - show a test summary table.
 - lint - Support local schema (#46).
-- convert to rdf (#52)
 
 ## [0.9.4] - 2024-02-18
 

--- a/README.md
+++ b/README.md
@@ -347,23 +347,40 @@ run.result
 
 Available export options:
 
-| Type         | Description                                    | Status |
-|--------------|------------------------------------------------|--------|
-| `jsonschema` | Export to JSON Schema                          | ✅      | 
-| `sodacl`     | Export to SodaCL quality checks in YAML format | ✅      |
-| `dbt`        | Export to dbt model in YAML format             | ✅      |
-| `avro`       | Export to AVRO models                          | TBD    |
-| `pydantic`   | Export to pydantic models                      | TBD    |
-| `sql`        | Export to SQL DDL                              | TBD    |
-| `protobuf`   | Export to Protobuf                             | TBD    |
+| Type         | Description                                             | Status |
+|--------------|---------------------------------------------------------|--------|
+| `jsonschema` | Export to JSON Schema                                   | ✅      | 
+| `sodacl`     | Export to SodaCL quality checks in YAML format          | ✅      |
+| `dbt`        | Export to dbt model in YAML format                      | ✅      |
+| `rdf`        | Export data contract to RDF representation in N3 format | ✅      |
+| `avro`       | Export to AVRO models                                   | TBD    |
+| `pydantic`   | Export to pydantic models                               | TBD    |
+| `sql`        | Export to SQL DDL                                       | TBD    |
+| `protobuf`   | Export to Protobuf                                      | TBD    |
 
-### Convert
+#### RDF
 
-The convert function converts a given data contract into a RDF representation. 
+The export function converts a given data contract into a RDF representation. You have the option to 
+add a base_url which will be used as the default prefix to resolve relative IRIs inside the document.
 
 ```shell
-datacontract --format rdf --base https://www.example.com/ datacontract.yaml
-``` 
+datacontract export --format rdf --rdf-base https://www.example.com/ datacontract.yaml
+```
+
+The data contract is mapped onto the following concepts of a yet to be defined Data Contract
+Ontology named https://datacontract.com/DataContractSpecification/ :
+- DataContract
+- Server
+- Model
+
+Having the data contract inside an RDF Graph gives us access the following use cases:
+- Interoperability with other data contract specification formats
+- Store data contracts inside a knowledge graph
+- Enhance a semantic search to find and retrieve data contracts
+- Linking model elements to already established ontologies and knowledge
+- Using full power of OWL to reason about the graph structure of data contracts
+- Apply graph algorithms on multiple data contracts (Find similar data contracts, find "gatekeeper"
+data products, find the true domain owner of a field attribute)
 
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -357,6 +357,15 @@ Available export options:
 | `sql`        | Export to SQL DDL                              | TBD    |
 | `protobuf`   | Export to Protobuf                             | TBD    |
 
+### Convert
+
+The convert function converts a given data contract into a RDF representation. 
+
+```shell
+datacontract --format rdf --base https://www.example.com/ datacontract.yaml
+``` 
+
+
 ## Development Setup
 
 Python base interpreter should be 3.11.x (unless working on 3.12 release candidate).

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -118,11 +118,13 @@ class ExportFormat(str, Enum):
     sodacl = "sodacl"
     dbt = "dbt"
     odcs = "odcs"
+    rdf = "rdf"
 
 
 @app.command()
 def export(
     format: Annotated[ExportFormat, typer.Option(help="The export format.")],
+    rdf_base: Annotated[Optional[str], typer.Option(help="The base URI used to generate the RDF graph.")] = "",
     location: Annotated[
         str, typer.Argument(help="The location (url or path) of the data contract yaml.")] = "datacontract.yaml",
 ):
@@ -130,24 +132,9 @@ def export(
     Convert data contract to a specific format. Prints to stdout.
     """
     # TODO exception handling
-    result = DataContract(data_contract_file=location).export(format)
+    result = DataContract(data_contract_file=location).export(format, rdf_base)
     print(result)
 
-class ConvertFormat(str, Enum):
-    rdf = "rdf"
-
-@app.command()
-def convert(
-    format: Annotated[ConvertFormat, typer.Option(help="The format to convert the data contract to.")],
-    base: Annotated[Optional[str], typer.Option(help="The base URI used to generate the RDF graph.")] = "",
-    location: Annotated[
-        str, typer.Argument(help="The location (url or path) of the data contract yaml.")] = "datacontract.yaml",
-):
-    """
-    Convert the data contract to a specific format. Prints to stdout
-    """
-    result = DataContract(data_contract_file=location).convert(format, base)
-    print(result)
 
 
 def _handle_result(run):

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from importlib import metadata
-from typing import Iterable
+from typing import Iterable, Optional
 
 import typer
 from click import Context
@@ -131,6 +131,22 @@ def export(
     """
     # TODO exception handling
     result = DataContract(data_contract_file=location).export(format)
+    print(result)
+
+class ConvertFormat(str, Enum):
+    rdf = "rdf"
+
+@app.command()
+def convert(
+    format: Annotated[ConvertFormat, typer.Option(help="The format to convert the data contract to.")],
+    base: Annotated[Optional[str], typer.Option(help="The base URI used to generate the RDF graph.")] = "",
+    location: Annotated[
+        str, typer.Argument(help="The location (url or path) of the data contract yaml.")] = "datacontract.yaml",
+):
+    """
+    Convert the data contract to a specific format. Prints to stdout
+    """
+    result = DataContract(data_contract_file=location).convert(format, base)
     print(result)
 
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -146,7 +146,7 @@ class DataContract:
     def diff(self, other):
         pass
 
-    def export(self, export_format, base) -> str:
+    def export(self, export_format, rdf_base) -> str:
         data_contract = resolve.resolve_data_contract(self._data_contract_file, self._data_contract_str,
                                                       self._data_contract)
         if export_format == "jsonschema":
@@ -159,20 +159,10 @@ class DataContract:
             return to_dbt(data_contract)
         if export_format == "odcs":
             return to_odcs(data_contract)
+        if export_format == "rdf":
+            return to_rdf(data_contract, rdf_base).serialize(format='n3')
         else:
             print(f"Export format {export_format} not supported.")
-            return ""
-
-    def convert(self, convert_format, base) -> str:
-        data_contract = resolve.resolve_data_contract(self._data_contract_file, self._data_contract_str,
-                                                      self._data_contract)
-        if convert_format == "rdf":
-            if base is not None:
-                return to_rdf(data_contract, base).serialize(format="n3")
-            else:
-                return to_rdf(data_contract, "").serialize(format="n3")
-        else:
-            print(f"Convert format {convert_format} not supported.")
             return ""
 
 

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -13,6 +13,7 @@ from datacontract.export.dbt_converter import to_dbt
 from datacontract.export.jsonschema_converter import to_jsonschema
 from datacontract.export.odcs_converter import to_odcs
 from datacontract.export.sodacl_converter import to_sodacl
+from datacontract.export.rdf_converter import to_rdf
 from datacontract.integration.publish_datamesh_manager import \
     publish_datamesh_manager
 from datacontract.lint import resolve
@@ -145,7 +146,7 @@ class DataContract:
     def diff(self, other):
         pass
 
-    def export(self, export_format) -> str:
+    def export(self, export_format, base) -> str:
         data_contract = resolve.resolve_data_contract(self._data_contract_file, self._data_contract_str,
                                                       self._data_contract)
         if export_format == "jsonschema":
@@ -161,6 +162,19 @@ class DataContract:
         else:
             print(f"Export format {export_format} not supported.")
             return ""
+
+    def convert(self, convert_format, base) -> str:
+        data_contract = resolve.resolve_data_contract(self._data_contract_file, self._data_contract_str,
+                                                      self._data_contract)
+        if convert_format == "rdf":
+            if base is not None:
+                return to_rdf(data_contract, base).serialize(format="n3")
+            else:
+                return to_rdf(data_contract, "").serialize(format="n3")
+        else:
+            print(f"Convert format {export_format} not supported.")
+            return ""
+
 
     def _get_examples_server(self, data_contract, run, tmp_dir):
         run.log_info(f"Copying examples to files in temporary directory {tmp_dir}")

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -172,7 +172,7 @@ class DataContract:
             else:
                 return to_rdf(data_contract, "").serialize(format="n3")
         else:
-            print(f"Convert format {export_format} not supported.")
+            print(f"Convert format {convert_format} not supported.")
             return ""
 
 

--- a/datacontract/export/rdf_converter.py
+++ b/datacontract/export/rdf_converter.py
@@ -1,0 +1,147 @@
+from typing import Dict
+import inspect
+from pydantic import BaseModel
+from rdflib import Graph, Literal, BNode, RDF, URIRef, Namespace
+
+from datacontract.model.data_contract_specification import \
+    DataContractSpecification, Model, Field
+
+
+def is_literal(property_name):
+    return property_name in ["dataContractSpecification", "title", "version", "description", "name", "url", "type",
+                             "location", "format", "delimiter", "usage", "limitations",
+                             "billing", "noticePeriod", "required", "unique", "minLength", "maxLength", "example",
+                             "pii", "classification", "data", "enum", "minimum", "maximum", "patterns"]
+
+
+def is_uriref(property_name):
+    return property_name in ["model", "domain", "owner"]
+
+
+def to_rdf(data_contract_spec: DataContractSpecification, base):
+    if base is not None:
+        g = Graph(base=base)
+    else:
+        g = Graph(base=Namespace(""))
+
+    dc = Namespace("https://datacontract.com/DataContractSpecification/0.9.2/")
+    dcx = Namespace("https://datacontract.com/DataContractSpecification/0.9.2/Extension/")
+
+    g.bind("dc", dc)
+    g.bind("dcx", dcx)
+
+    this_contract = URIRef(data_contract_spec.id)
+
+    g.add((this_contract, dc.dataContractSpecification, Literal(data_contract_spec.dataContractSpecification)))
+    g.add((this_contract, dc.id, Literal(data_contract_spec.id)))
+    g.add((this_contract, RDF.type, URIRef(dc + "DataContract")))
+
+    add_info(contract=this_contract, info=data_contract_spec.info, graph=g, dc=dc, dcx=dcx)
+
+    if data_contract_spec.terms is not None:
+        add_terms(contract=this_contract, terms=data_contract_spec.terms, graph=g, dc=dc, dcx=dcx)
+
+    for server_name, server in data_contract_spec.servers.items():
+        add_server(contract=this_contract, server=server, server_name=server_name, graph=g, dc=dc, dcx=dcx)
+
+    for model_name, model in data_contract_spec.models.items():
+        add_model(contract=this_contract, model=model, model_name=model_name, graph=g, dc=dc, dcx=dcx)
+
+    for example in data_contract_spec.examples:
+        add_example(contract=this_contract, example=example, graph=g, dc=dc, dcx=dcx)
+
+    g.commit()
+    g.close()
+
+    return g
+
+
+def add_example(contract, example, graph, dc, dcx):
+    an_example = BNode()
+    graph.add((contract, dc['example'], an_example))
+    graph.add((an_example, RDF.type, URIRef(dc + "Example")))
+    for example_property in example.model_fields:
+        add_triple(sub=an_example, pred=example_property, obj=example, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_triple(sub, pred, obj, graph, dc, dcx):
+    if pred == "ref":
+        pass
+    elif isinstance(getattr(obj, pred), list):
+        for item in getattr(obj, pred):
+            add_predicate(sub=sub, pred=pred, obj=item, graph=graph, dc=dc, dcx=dcx)
+    elif isinstance(getattr(obj, pred), dict):
+        pass
+    else:
+        add_predicate(sub=sub, pred=pred, obj=obj, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_model(contract, model, model_name, graph, dc, dcx):
+    a_model = URIRef(model_name)
+    graph.add((contract, dc['model'], a_model))
+    graph.add((a_model, dc.description, Literal(model.description)))
+    graph.add((a_model, RDF.type, URIRef(dc + "Model")))
+    for field_name, field in model.fields.items():
+        a_field = BNode()
+        graph.add((a_model, dc['field'], a_field))
+        graph.add((a_field, RDF.type, URIRef(dc + "Field")))
+        graph.add((a_field, dc['name'], Literal(field_name)))
+        for field_property in field.model_fields:
+            add_triple(sub=a_field, pred=field_property, obj=field, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_server(contract, server, server_name, graph, dc, dcx):
+    a_server = URIRef(server_name)
+    graph.add((contract, dc.server, a_server))
+    graph.add((a_server, RDF.type, URIRef(dc + "Server")))
+    for server_property_name in server.model_fields:
+        add_triple(sub=a_server, pred=server_property_name, obj=server, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_terms(contract, terms, graph, dc, dcx):
+    bnode_terms = BNode()
+    graph.add((contract, dc.terms, bnode_terms))
+    graph.add((bnode_terms, RDF.type, URIRef(dc + "Terms")))
+    for term_name in terms.model_fields:
+        add_triple(sub=bnode_terms, pred=term_name, obj=terms, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_info(contract, info, graph, dc, dcx):
+    bnode_info = BNode()
+    graph.add((contract, dc.info, bnode_info))
+    graph.add((bnode_info, RDF.type, URIRef(dc + "Info")))
+    graph.add((bnode_info, dc.title, Literal(info.title)))
+    graph.add((bnode_info, dc.description, Literal(info.description)))
+    graph.add((bnode_info, dc.version, Literal(info.version)))
+
+    # add owner
+    owner = URIRef(info.owner)
+    graph.add((bnode_info, dc.owner, owner))
+
+    # add contact
+    contact = BNode()
+    graph.add((bnode_info, dc.contact, contact))
+    graph.add((contact, RDF.type, URIRef(dc + "Contact")))
+    for contact_property in info.contact.model_fields:
+        add_triple(sub=contact, pred=contact_property, obj=info.contact, graph=graph, dc=dc, dcx=dcx)
+
+
+def add_predicate(sub, pred, obj, graph, dc, dcx):
+    if isinstance(obj, BaseModel):
+        if getattr(obj, pred) is not None:
+            if is_literal(pred):
+                graph.add((sub, dc[pred], Literal(getattr(obj, pred))))
+            elif is_uriref(pred):
+                graph.add((sub, dc[pred], URIRef(getattr(obj, pred))))
+            else:
+                # treat it as an extension
+                graph.add((sub, dcx[pred], Literal(getattr(obj, pred))))
+    else:
+        # assume primitive
+        if is_literal(pred):
+            graph.add((sub, dc[pred], Literal(obj)))
+        elif is_uriref(pred):
+            graph.add((sub, dc[pred], URIRef(obj)))
+        else:
+            # treat it as an extension
+            graph.add((sub, dcx[pred], Literal(obj)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "fastjsonschema~=2.19.1",
   "python-dotenv~=1.0.0",
   "s3fs==2024.2.0",
+  "rdflib==7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/examples/export/rdf/datacontract-complex.yaml
+++ b/tests/examples/export/rdf/datacontract-complex.yaml
@@ -1,0 +1,129 @@
+dataContractSpecification: 0.9.2
+id: orders-latest
+info:
+  title: Orders Latest
+  version: 1.0.0
+  description: |
+    Successful customer orders in the webshop. All orders since 2020-01-01. Orders with their line items are in their current state (no history included).
+  owner: urn:acme:CheckoutTeam
+  contact:
+    name: John Doe (Data Product Owner)
+    url: https://teams.microsoft.com/l/channel/acme/checkout
+servers:
+  production:
+    type: "s3"
+    endpointUrl: __S3_ENDPOINT_URL__
+    location: "s3://multiple-bucket/examples/s3-json-multiple-models/data/{model}/*.json"
+    format: "json"
+    delimiter: "new_line"
+terms:
+  usage: >
+    Data can be used for reports, analytics and machine learning use cases.
+    Order may be linked and joined by other tables
+  limitations: >
+    Not suitable for real-time use cases.
+    Data may not be used to identify individual customers.
+    Max data processing per day: 10 TiB
+  billing: 5000 USD per month
+  noticePeriod: P3M
+models:
+  orders:
+    description: One record per order. Includes cancelled and deleted orders.
+    type: table
+    fields:
+      order_id:
+        $ref: '#/definitions/order_id'
+        required: true
+        unique: true
+      order_timestamp:
+        description: The business timestamp in UTC when the order was successfully registered in the source system and the payment was successful.
+        type: timestamp
+        required: true
+      order_total:
+        description: Total amount the smallest monetary unit (e.g., cents).
+        type: long
+        required: true
+      customer_id:
+        description: Unique identifier for the customer.
+        type: text
+        minLength: 10
+        maxLength: 20
+      customer_email_address:
+        description: The email address, as entered by the customer. The email address was not verified.
+        type: text
+        format: email
+        required: true
+  line_items:
+    description: A single article that is part of an order.
+    type: table
+    fields:
+      lines_item_id:
+        type: text
+        description: Primary key of the lines_item_id table
+        required: true
+        unique: true
+      order_id:
+        $ref: '#/definitions/order_id'
+      sku:
+        description: The purchased article number
+        $ref: '#/definitions/sku'
+definitions:
+  order_id:
+    domain: checkout
+    name: order_id
+    title: Order ID
+    type: text
+    format: uuid
+    description: An internal ID that identifies an order in the online shop.
+    example: 243c25e5-a081-43a9-aeab-6d5d5b6cb5e2
+    pii: true
+    classification: restricted
+  sku:
+    domain: inventory
+    name: sku
+    title: Stock Keeping Unit
+    type: text
+    pattern: ^[A-Za-z0-9]{8,14}$
+    example: "96385074"
+    description: |
+      A Stock Keeping Unit (SKU) is an internal unique identifier for an article. 
+      It is typically associated with an article's barcode, such as the EAN/GTIN.
+examples:
+  - type: csv # csv, json, yaml, custom
+    model: orders
+    data: |- # expressed as string or inline yaml or via "$ref: data.csv"
+      order_id,order_timestamp,order_total
+      "1001","2023-09-09T08:30:00Z",2500
+      "1002","2023-09-08T15:45:00Z",1800
+      "1003","2023-09-07T12:15:00Z",3200
+      "1004","2023-09-06T19:20:00Z",1500
+      "1005","2023-09-05T10:10:00Z",4200
+      "1006","2023-09-04T14:55:00Z",2800
+      "1007","2023-09-03T21:05:00Z",1900
+      "1008","2023-09-02T17:40:00Z",3600
+      "1009","2023-09-01T09:25:00Z",3100
+      "1010","2023-08-31T22:50:00Z",2700
+  - type: csv
+    model: line_items
+    data: |-
+      lines_item_id,order_id,sku
+      "1","1001","5901234123457"
+      "2","1001","4001234567890"
+      "3","1002","5901234123457"
+      "4","1002","2001234567893"
+      "5","1003","4001234567890"
+      "6","1003","5001234567892"
+      "7","1004","5901234123457"
+      "8","1005","2001234567893"
+      "9","1005","5001234567892"
+      "10","1005","6001234567891"
+quality:
+  type: SodaCL   # data quality check format: SodaCL, montecarlo, custom
+  specification: # expressed as string or inline yaml or via "$ref: checks.yaml"
+    checks for orders:
+      - freshness(order_timestamp) < 24h
+      - row_count >= 5000
+      - duplicate_count(order_id) = 0
+    checks for line_items:
+      - values in (order_id) must exist in orders (order_id)
+      - row_count >= 5000

--- a/tests/examples/export/rdf/datacontract.yaml
+++ b/tests/examples/export/rdf/datacontract.yaml
@@ -1,0 +1,42 @@
+dataContractSpecification: 0.9.2
+id: orders-unit-test
+info:
+  title: Orders Unit Test
+  version: 1.0.0
+  owner: urn:acme:checkout
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
+terms:
+  usage: This data contract serves to demo datacontract CLI export.
+  limitations: Not intended to use in production
+  billing: free
+  noticePeriod: P3M
+models:
+  orders:
+    description: The orders model
+    fields:
+      order_id:
+        type: varchar
+        unique: true
+        required: true
+        minLength: 8
+        maxLength: 10
+        pii: true
+        classification: sensitive
+        tags:
+          - order_id
+        pattern: ^B[0-9]+$
+      order_total:
+        type: bigint
+        required: true
+        description: The order_total field
+        minimum: 0
+        maximum: 1000000
+      order_status:
+        type: text
+        required: true
+        enum:
+          - pending
+          - shipped
+          - delivered

--- a/tests/examples/local-json/datacontract.yaml
+++ b/tests/examples/local-json/datacontract.yaml
@@ -134,7 +134,7 @@ definitions:
       berichtigte Zahl
       s
       geschätzte Zahl
-verbraucherpreisindex:
+examples:
   - type: json
     description: Example entry for CPI data
     model: ConsumerPriceIndex

--- a/tests/test_convert_rdf.py
+++ b/tests/test_convert_rdf.py
@@ -1,0 +1,225 @@
+import json
+import logging
+import os
+import sys
+
+from typer.testing import CliRunner
+
+from rdflib.graph import Graph, Namespace
+from rdflib.compare import graph_diff, to_isomorphic, to_canonical_graph
+
+from datacontract.cli import app
+from datacontract.export.rdf_converter import to_rdf
+from datacontract.model.data_contract_specification import \
+    DataContractSpecification
+
+logging.basicConfig(level=logging.DEBUG, force=True)
+
+
+def test_cli():
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "convert",
+        "./examples/export/rdf/datacontract.yaml",
+        "--format", "rdf",
+        "--base", "urn:acme:"
+    ])
+    assert result.exit_code == 0
+
+
+def test_to_rdf():
+    data_contract_file = ("./examples/export/rdf/datacontract.yaml")
+    file_content = read_file(data_contract_file=data_contract_file)
+    data_contract = DataContractSpecification.from_string(file_content)
+    expected_rdf = """
+@prefix dc1: <https://datacontract.com/DataContractSpecification/0.9.2/> .
+@prefix dcx: <https://datacontract.com/DataContractSpecification/0.9.2/Extension/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://example.com/orders-unit-test> a dc1:DataContract ;
+    dc1:dataContractSpecification "0.9.2" ;
+    dc1:id "orders-unit-test" ;
+    dc1:info [ a dc1:Info ;
+            dc1:contact [ a dc1:Contact ;
+                dcx:email "team-orders@example.com" ;
+                dc1:url "https://wiki.example.com/teams/checkout" ] ;
+            dc1:description "None" ;
+            dc1:owner <urn:acme:checkout> ;
+            dc1:title "Orders Unit Test" ;
+            dc1:version "1.0.0" ] ;
+    dc1:model <https://example.com/orders> ;
+    dc1:terms [ a dc1:Terms ;
+            dc1:billing "free" ;
+            dc1:limitations "Not intended to use in production" ;
+            dc1:noticePeriod "P3M" ;
+            dc1:usage "This data contract serves to demo datacontract CLI export." ] .
+
+<https://example.com/orders> a dc1:Model ;
+    dc1:description "The orders model" ;
+    dc1:field [ a dc1:Field ;
+            dc1:description "The order_total field" ;
+            dc1:maximum 1000000 ;
+            dc1:minimum 0 ;
+            dc1:name "order_total" ;
+            dc1:required true ;
+            dc1:type "bigint" ],
+        [ a dc1:Field ;
+            dc1:enum "delivered",
+                "pending",
+                "shipped" ;
+            dc1:name "order_status" ;
+            dc1:required true ;
+            dc1:type "text" ],
+        [ a dc1:Field ;
+            dcx:pattern "^B[0-9]+$" ;
+            dcx:tags "order_id" ;
+            dc1:classification "sensitive" ;
+            dc1:maxLength 10 ;
+            dc1:minLength 8 ;
+            dc1:name "order_id" ;
+            dc1:pii true ;
+            dc1:required true ;
+            dc1:type "varchar" ;
+            dc1:unique true ] .
+
+"""
+    g = Graph().parse(format='n3', data=expected_rdf)
+
+    result = to_rdf(data_contract, "https://example.com/")
+
+    iso_g1 = to_isomorphic(Graph().parse(data=g.serialize()))
+    iso_result = to_isomorphic(Graph().parse(data=result.serialize()))
+
+    assert iso_g1 == iso_result
+
+def test_to_rdf_complex():
+    data_contract_file = ("./examples/export/rdf/datacontract-complex.yaml")
+    file_content = read_file(data_contract_file=data_contract_file)
+    data_contract = DataContractSpecification.from_string(file_content)
+    expected_rdf = """
+@base <http://test.com/> .
+@prefix dc1: <https://datacontract.com/DataContractSpecification/0.9.2/> .
+@prefix dcx: <https://datacontract.com/DataContractSpecification/0.9.2/Extension/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<orders-latest> a dc1:DataContract ;
+    dc1:dataContractSpecification "0.9.2" ;
+    dc1:example [ a dc1:Example ;
+            dc1:data \"\"\"order_id,order_timestamp,order_total
+"1001","2023-09-09T08:30:00Z",2500
+"1002","2023-09-08T15:45:00Z",1800
+"1003","2023-09-07T12:15:00Z",3200
+"1004","2023-09-06T19:20:00Z",1500
+"1005","2023-09-05T10:10:00Z",4200
+"1006","2023-09-04T14:55:00Z",2800
+"1007","2023-09-03T21:05:00Z",1900
+"1008","2023-09-02T17:40:00Z",3600
+"1009","2023-09-01T09:25:00Z",3100
+"1010","2023-08-31T22:50:00Z",2700\"\"\" ;
+            dc1:model <orders> ;
+            dc1:type "csv" ],
+        [ a dc1:Example ;
+            dc1:data \"\"\"lines_item_id,order_id,sku
+"1","1001","5901234123457"
+"2","1001","4001234567890"
+"3","1002","5901234123457"
+"4","1002","2001234567893"
+"5","1003","4001234567890"
+"6","1003","5001234567892"
+"7","1004","5901234123457"
+"8","1005","2001234567893"
+"9","1005","5001234567892"
+"10","1005","6001234567891\\"\"\"\" ;
+            dc1:model <line_items> ;
+            dc1:type "csv" ] ;
+    dc1:id "orders-latest" ;
+    dc1:info [ a dc1:Info ;
+            dc1:contact [ a dc1:Contact ;
+                dc1:name "John Doe (Data Product Owner)" ;
+                dc1:url "https://teams.microsoft.com/l/channel/acme/checkout" ] ;
+            dc1:description \"\"\"Successful customer orders in the webshop. All orders since 2020-01-01. Orders with their line items are in their current state (no history included).
+\"\"\" ;
+            dc1:owner <urn:acme:CheckoutTeam> ;
+            dc1:title "Orders Latest" ;
+            dc1:version "1.0.0" ] ;
+    dc1:model <line_items>,
+        <orders> ;
+    dc1:server <production> ;
+    dc1:terms [ a dc1:Terms ;
+            dc1:billing "5000 USD per month" ;
+            dc1:limitations \"\"\"Not suitable for real-time use cases. Data may not be used to identify individual customers. Max data processing per day: 10 TiB
+\"\"\" ;
+            dc1:noticePeriod "P3M" ;
+            dc1:usage \"\"\"Data can be used for reports, analytics and machine learning use cases. Order may be linked and joined by other tables
+\"\"\" ] .
+
+<production> a dc1:Server ;
+    dcx:endpointUrl "__S3_ENDPOINT_URL__" ;
+    dc1:delimiter "new_line" ;
+    dc1:format "json" ;
+    dc1:location "s3://multiple-bucket/examples/s3-json-multiple-models/data/{model}/*.json" ;
+    dc1:type "s3" .
+
+<line_items> a dc1:Model ;
+    dc1:description "A single article that is part of an order." ;
+    dc1:field [ a dc1:Field ;
+            dc1:description "Primary key of the lines_item_id table" ;
+            dc1:name "lines_item_id" ;
+            dc1:required true ;
+            dc1:type "text" ;
+            dc1:unique true ],
+        [ a dc1:Field ;
+            dc1:name "order_id" ],
+        [ a dc1:Field ;
+            dc1:description "The purchased article number" ;
+            dc1:name "sku" ] .
+
+<orders> a dc1:Model ;
+    dc1:description "One record per order. Includes cancelled and deleted orders." ;
+    dc1:field [ a dc1:Field ;
+            dc1:name "order_id" ;
+            dc1:required true ;
+            dc1:unique true ],
+        [ a dc1:Field ;
+            dc1:description "The business timestamp in UTC when the order was successfully registered in the source system and the payment was successful." ;
+            dc1:name "order_timestamp" ;
+            dc1:required true ;
+            dc1:type "timestamp" ],
+        [ a dc1:Field ;
+            dc1:description "The email address, as entered by the customer. The email address was not verified." ;
+            dc1:format "email" ;
+            dc1:name "customer_email_address" ;
+            dc1:required true ;
+            dc1:type "text" ],
+        [ a dc1:Field ;
+            dc1:description "Unique identifier for the customer." ;
+            dc1:maxLength 20 ;
+            dc1:minLength 10 ;
+            dc1:name "customer_id" ;
+            dc1:type "text" ],
+        [ a dc1:Field ;
+            dc1:description "Total amount the smallest monetary unit (e.g., cents)." ;
+            dc1:name "order_total" ;
+            dc1:required true ;
+            dc1:type "long" ] .
+
+"""
+
+    g = Graph().parse(format='n3', data=expected_rdf)
+
+    result = to_rdf(data_contract, base="http://test.com/")
+
+    iso_g1 = to_isomorphic(Graph().parse(data=g.serialize()))
+    iso_result = to_isomorphic(Graph().parse(data=result.serialize()))
+
+    assert iso_g1 == iso_result
+
+
+
+def read_file(data_contract_file):
+    if not os.path.exists(data_contract_file):
+        print(f"The file '{data_contract_file}' does not exist.")
+        sys.exit(1)
+    with open(data_contract_file, 'r') as file:
+        file_content = file.read()
+    return file_content

--- a/tests/test_export_rdf.py
+++ b/tests/test_export_rdf.py
@@ -19,10 +19,19 @@ logging.basicConfig(level=logging.DEBUG, force=True)
 def test_cli():
     runner = CliRunner()
     result = runner.invoke(app, [
-        "convert",
+        "export",
         "./examples/export/rdf/datacontract.yaml",
         "--format", "rdf",
-        "--base", "urn:acme:"
+        "--rdf-base", "urn:acme:"
+    ])
+    assert result.exit_code == 0
+
+def test_no_rdf_base():
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "export",
+        "./examples/export/rdf/datacontract.yaml",
+        "--format", "rdf"
     ])
     assert result.exit_code == 0
 


### PR DESCRIPTION
- cli command "convert" converts a given data contract into a RDF representation
- add rdflib 7.0.0 dependency

I choose to implement a new cli function convert over extending the export function because the goal was to get an RDF representation of a given contract rather than creating a schema representation of the data model. Further exploration into the RDF topic might involve adding export functionality using the RDB2RDF mapping (see https://www.w3.org/2001/sw/wiki/RDB2RDF).

The convert function maps a data contract and its properties into the concepts DataContract, Server, Model, Field, Contact, Info, Terms and Example.

For example the following data contract

```yaml
dataContractSpecification: 0.9.2
id: orders-unit-test
info:
  title: Orders Unit Test
  version: 1.0.0
```

Is mapped to the following RDF triple
```yaml
@prefix dc1: <https://datacontract.com/DataContractSpecification/0.9.2/> .

<orders-unit-test> a dc1:DataContract ;
    dc1:dataContractSpecification "0.9.2" ;
    dc1:id "orders-unit-test" ;
    dc1:info [ a dc1:Info ;
            dc1:title "Orders Unit Test" ;
            dc1:version "1.0.0" ] .
```

Each model of a data contract is mapped to a single Model instance.

```yaml
models:
  orders:
    description: The orders model
  line_items:
    description: The line items model
```

is mapped into

```yaml
@prefix dc1: <https://datacontract.com/DataContractSpecification/0.9.2/> .

<orders> a dc1:Model ;
    dc1:description "The orders model" .

<line_items> a dc1:Model ;
    dc1:description "The line items model" .
```