### PR TITLE
Implement Avro IDL converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added export format **protobuf**: `datacontract export --format protobuf`
 - Added export format **terraform**: `datacontract export --format terraform`
 - Added extensive linting on data contracts. `datacontract lint` will now check for a variety of possible errors in the data contract, such as missing descriptions, incorrect references to models or fields, nonsensical constraints, and more.
-- Added changelog command: `datacontract changelog` will now generate a changelog based on the changes in the data contract. This will be useful for keeping track of changes in the data contract over time. 
+- Added changelog command: `datacontract changelog` will now generate a changelog based on the changes in the data contract. This will be useful for keeping track of changes in the data contract over time.
+- Added Avro IDL export: Generates an Avro IDL file containing records for each model.
 
 ## [0.9.6-2] - 2024-03-04
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -127,6 +127,7 @@ class ExportFormat(str, Enum):
     avro = "avro"
     protobuf = "protobuf"
     terraform = "terraform"
+    avro_idl = "avro-idl"
 
 
 @app.command()

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -12,6 +12,7 @@ from datacontract.engines.fastjsonschema.check_jsonschema import \
     check_jsonschema
 from datacontract.engines.soda.check_soda_execute import check_soda_execute
 from datacontract.export.avro_converter import to_avro_schema, to_avro_schema_json
+from datacontract.export.avro_idl_converter import to_avro_idl
 from datacontract.export.dbt_converter import to_dbt_models_yaml, \
     to_dbt_sources_yaml, to_dbt_staging_sql
 from datacontract.export.jsonschema_converter import to_jsonschema, to_jsonschema_json
@@ -309,6 +310,8 @@ class DataContract:
             return to_odcs_yaml(data_contract)
         if export_format == "rdf":
             return to_rdf_n3(data_contract, rdf_base)
+        if export_format == "avro-idl":
+            return to_avro_idl(data_contract)
         if export_format == "protobuf":
             return to_protobuf(data_contract)
         if export_format == "avro":

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -310,8 +310,6 @@ class DataContract:
             return to_odcs_yaml(data_contract)
         if export_format == "rdf":
             return to_rdf_n3(data_contract, rdf_base)
-        if export_format == "avro-idl":
-            return to_avro_idl(data_contract)
         if export_format == "protobuf":
             return to_protobuf(data_contract)
         if export_format == "avro":
@@ -333,6 +331,8 @@ class DataContract:
                     raise RuntimeError(f"Model {model_name} not found in the data contract. Available models: {model_names}")
 
                 return to_avro_schema_json(model_name, model_value)
+        if export_format == "avro-idl":
+            return to_avro_idl(data_contract)
         if export_format == "terraform":
             return to_terraform(data_contract)
         else:

--- a/datacontract/export/avro_idl_converter.py
+++ b/datacontract/export/avro_idl_converter.py
@@ -7,6 +7,27 @@ from io import StringIO
 
 from datacontract.model.exceptions import DataContractException
 
+def to_avro_idl(contract: DataContractSpecification) -> str:
+    """Serialize the provided data contract specification into an Avro IDL string.
+
+    The data contract will be serialized as a protocol, with one record type
+    for each contained model. Model fields are mapped one-to-one to Avro IDL
+    record fields.
+    """
+    stream = StringIO()
+    to_avro_idl_stream(contract, stream)
+    return stream.getvalue()
+
+def to_avro_idl_stream(contract: DataContractSpecification, stream: typing.TextIO):
+    """Serialize the provided data contract specification into Avro IDL."""
+    ir = _contract_to_avro_idl_ir(contract)
+    if ir.description:
+        stream.write(f"/** {contract.info.description} */\n")
+    stream.write(f"protocol {ir.name or 'Unnamed'} {{\n")
+    for model_type in ir.model_types:
+        _write_model_type(model_type, stream)
+    stream.write("}\n")
+
 class AvroPrimitiveType(Enum):
     int = "int"
     long = "long"
@@ -26,6 +47,7 @@ class AvroLogicalType(Enum):
 @dataclass
 class AvroField:
     name: str
+    required: bool
     description: typing.Optional[str]
 
 @dataclass
@@ -41,7 +63,9 @@ class AvroArrayField(AvroField):
     type: AvroField
 
 @dataclass
-class AvroModelType(AvroField):
+class AvroModelType:
+    name: str
+    description: typing.Optional[str]
     fields: list[AvroField]
 
 @dataclass
@@ -58,8 +82,8 @@ avro_primitive_types = set(["string", "text", "varchar",
                             "date", "bytes",
                             "null"])
 
-def to_avro_primitive_logical_type(field_name: str, field: Field) -> AvroPrimitiveField:
-    result = AvroPrimitiveField(field_name, field.description, AvroPrimitiveType.string)
+def _to_avro_primitive_logical_type(field_name: str, field: Field) -> AvroPrimitiveField:
+    result = AvroPrimitiveField(field_name, field.required, field.description, AvroPrimitiveType.string)
     match field.type:
         case "string" | "text" | "varchar":
             result.type = AvroPrimitiveType.string
@@ -94,22 +118,24 @@ def to_avro_primitive_logical_type(field_name: str, field: Field) -> AvroPrimiti
             )
     return result
 
-def to_avro_idl_type(field_name: str, field: Field) -> AvroField:
+def _to_avro_idl_type(field_name: str, field: Field) -> AvroField:
     if field.type in avro_primitive_types:
-        return to_avro_primitive_logical_type(field_name, field)
+        return _to_avro_primitive_logical_type(field_name, field)
     else:
         match field.type:
             case "array":
                 return AvroArrayField(
                     field_name,
+                    field.required,
                     field.description,
-                    to_avro_idl_type(field_name, field.items)
+                    _to_avro_idl_type(field_name, field.items)
                 )
             case "object" | "record" | "struct":
                 return AvroComplexField(
                     field_name,
+                    field.required,
                     field.description,
-                    [to_avro_idl_type(field_name, field) for (field_name, field) in field.fields.items()]
+                    [_to_avro_idl_type(field_name, field) for (field_name, field) in field.fields.items()]
                 )
             case _:
                 raise DataContractException(
@@ -122,11 +148,11 @@ def to_avro_idl_type(field_name: str, field: Field) -> AvroField:
                 )
 
 
-def generate_field_types(contract: DataContractSpecification) -> list[AvroField]:
+def _generate_field_types(contract: DataContractSpecification) -> list[AvroField]:
     result = []
     for (_, model) in contract.models.items():
         for (field_name, field) in model.fields.items():
-            result.append(to_avro_idl_type(field_name, field))
+            result.append(_to_avro_idl_type(field_name, field))
     return result
 
 def generate_model_types(contract: DataContractSpecification) -> list[AvroModelType]:
@@ -135,21 +161,22 @@ def generate_model_types(contract: DataContractSpecification) -> list[AvroModelT
         result.append(AvroModelType(
             name=model_name,
             description=model.description,
-            fields=generate_field_types(contract)
+            fields=_generate_field_types(contract)
         ))
     return result
 
-def model_name_to_identifier(model_name: str):
+def _model_name_to_identifier(model_name: str):
     return "".join([word.title() for word in  model_name.split()])
 
-def contract_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProtocol:
+def _contract_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProtocol:
+
     """Convert models into an intermediate representation for later serialization into Avro IDL.
 
       Each model is converted to a record containing a field for each model field.
       """
     inlined_contract = contract.model_copy()
     inline_definitions_into_data_contract(inlined_contract)
-    protocol_name = (model_name_to_identifier(contract.info.title)
+    protocol_name = (_model_name_to_identifier(contract.info.title)
                      if contract.info and contract.info.title
                      else None)
     description = (contract.info.description if
@@ -159,67 +186,72 @@ def contract_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProto
                            description=description,
                            model_types=generate_model_types(inlined_contract))
 
-def write_indent(indent: int, stream: typing.TextIO):
+def _write_indent(indent: int, stream: typing.TextIO):
     stream.write("    " * indent)
 
-def write_field_description(field: AvroField, indent: int, stream: typing.TextIO):
+def _write_field_description(field: AvroField, indent: int, stream: typing.TextIO):
     if field.description:
-        write_indent(indent, stream)
+        _write_indent(indent, stream)
         stream.write(f"/** {field.description} */\n")
 
-def write_field_type_definition(field: AvroField, indent: int, stream: typing.TextIO) -> str:
+def _write_field_type_definition(field: AvroField, indent: int, stream: typing.TextIO) -> str:
+    # Write any extra information (such as record type definition) and return
+    # the name of the generated type. Writes descriptions only for record
+    # types. This leads to record types being described twice, once on the
+    # record definition, and once on use. The alternative (detect when the
+    # complex field type is not used in an array or another complex type) is
+    # significantly more complex to implement.
     match field:
-        case AvroPrimitiveField(name, _, typ):
+        case AvroPrimitiveField(name, required, _, typ) if required is True:
             return typ.value
-        case AvroComplexField(name, _, subfields):
-            write_field_description(field, indent, stream)
-            write_indent(indent, stream)
+        case AvroPrimitiveField(name, required, _, typ):
+            return typ.value + "?"
+        case AvroComplexField(name, required, _, subfields):
+            _write_field_description(field, indent, stream)
+            _write_indent(indent, stream)
             stream.write(f"record {name}_type {{\n")
             subfield_types = []
+            # Recursively define records for all subfields if necessary
             for subfield in subfields:
-                subfield_types.append(write_field_type_definition(subfield, indent + 1, stream))
+                subfield_types.append(_write_field_type_definition(subfield, indent + 1, stream))
+            # Reference all defined record types.
             for (field, subfield_type) in zip(field.subfields, subfield_types):
-                write_field_description(field, indent + 1, stream)
-                write_indent(indent + 1, stream)
+                _write_field_description(field, indent + 1, stream)
+                _write_indent(indent + 1, stream)
                 stream.write(f"{subfield_type} {field.name};\n")
-            write_indent(indent, stream)
+            _write_indent(indent, stream)
             stream.write("}\n")
-            return f"{name}_type"
-        case AvroArrayField(name, _, item_type):
-            subfield_type = write_field_type_definition(item_type, indent, stream)
-            return f"array<{subfield_type}>"
+            if required is True:
+                return f"{name}_type"
+            else:
+                return f"{name}_type?"
+        case AvroArrayField(name, required, _, item_type):
+            subfield_type = _write_field_type_definition(item_type, indent, stream)
+            if required is True:
+                return f"array<{subfield_type}>"
+            else:
+                return f"array<{subfield_type}>?"
         case _:
             raise RuntimeError("Unknown Avro field type {field}")
 
-def write_field(field: AvroField,
+def _write_field(field: AvroField,
                 indent,
                 stream: typing.TextIO):
-    typename = write_field_type_definition(field, indent, stream)
-    write_field_description(field, indent, stream)
-    write_indent(indent, stream)
+    # Start of recursion.
+    typename = _write_field_type_definition(field, indent, stream)
+    _write_field_description(field, indent, stream)
+    _write_indent(indent, stream)
     stream.write(f"{typename} {field.name};\n")
 
-def write_model_type(model: AvroModelType, stream: typing.TextIO):
+def _write_model_type(model: AvroModelType, stream: typing.TextIO):
+    # Called once for each model
     if model.description:
-        write_indent(1, stream)
+        _write_indent(1, stream)
         stream.write(f"/** {model.description} */\n")
-    write_indent(1, stream)
+    _write_indent(1, stream)
     stream.write(f"record {model.name} {{\n")
+    # Called for each model field
     for field in model.fields:
-        write_field(field, 2, stream)
-    write_indent(1, stream)
-    stream.write("}\n")
-
-def to_avro_idl(contract: DataContractSpecification) -> str:
-    stream = StringIO()
-    to_avro_idl_stream(contract, stream)
-    return stream.getvalue()
-
-def to_avro_idl_stream(contract: DataContractSpecification, stream: typing.TextIO):
-    ir = contract_to_avro_idl_ir(contract)
-    if ir.description:
-        stream.write(f"/** {contract.info.description} */\n")
-    stream.write(f"protocol {ir.name or 'Unnamed'} {{\n")
-    for model_type in ir.model_types:
-        write_model_type(model_type, stream)
+        _write_field(field, 2, stream)
+    _write_indent(1, stream)
     stream.write("}\n")

--- a/datacontract/export/avro_idl_converter.py
+++ b/datacontract/export/avro_idl_converter.py
@@ -1,0 +1,170 @@
+from datacontract.model.data_contract_specification import DataContractSpecification
+from datacontract.lint.resolve import inline_definitions_into_data_contract
+from dataclasses import dataclass
+from enum import Enum
+import typing
+from io import StringIO
+
+from datacontract.model.exceptions import DataContractException
+
+class AvroPrimitiveType(Enum):
+    int = "int"
+    long = "long"
+    string = "string"
+    boolean = "boolean"
+    float = "float"
+    double = "double"
+    null = "null"
+    bytes = "bytes"
+
+class AvroLogicalType(Enum):
+    decimal = "decimal"
+    date = "date"
+    time_ms = "time_ms"
+    timestamp_ms = "timestamp_ms"
+
+@dataclass
+class AvroFieldType:
+    name: str
+    description: typing.Optional[str]
+    type: typing.Union[AvroPrimitiveType, AvroLogicalType]
+
+@dataclass
+class AvroModelType:
+    name: str
+    description: typing.Optional[str]
+    fields: list[AvroFieldType]
+
+@dataclass
+class AvroIDLProtocol:
+    name: str
+    description: typing.Optional[str]
+    model_types: list[AvroModelType]
+
+
+def to_avro_idl_type(type: str) -> typing.Union[AvroPrimitiveType, AvroLogicalType]:
+    match type:
+        case "string" | "text" | "varchar":
+            return AvroPrimitiveType.string
+        case "float":
+            return AvroPrimitiveType.float
+        case "double":
+            return AvroPrimitiveType.double
+        case "int" | "integer":
+            return AvroPrimitiveType.int
+        case "long" | "bigint":
+            return AvroPrimitiveType.long
+        case "boolean":
+            return AvroPrimitiveType.boolean
+        case "timestamp" | "timestamp_tz":
+            raise DataContractException(
+                type="general",
+                name="avro-idl-export",
+                model=type,
+                reason="Avro IDL does not support timestamps with timezone.",
+                result="failed",
+                message="Avro IDL type conversion failed."
+            )
+        case "timestamp_ntz":
+            return AvroLogicalType.timestamp_ms
+        case "date":
+            return AvroLogicalType.date
+        case "array":
+            raise DataContractException(
+                type="general",
+                name="avro-idl-export",
+                model=type,
+                reason="Avro IDL export for arrays is not implemented.",
+                result="failed",
+                message="Avro IDL type conversion failed."
+            )
+        case "object":
+            raise DataContractException(
+                type="general",
+                name="avro-idl-export",
+                model=type,
+                reason="Avro IDL export for objects is not implemented.",
+                result="failed",
+                message="Avro IDL type conversion failed."
+            )
+        case "record":
+             raise DataContractException(
+                 type="general",
+                 name="avro-idl-export",
+                 model=type,
+                 reason="Avro IDL export for records is currently not implemented.",
+                 result="failed",
+                 message="Avro IDL type conversion failed."
+             )
+        case "bytes":
+            return AvroPrimitiveType.bytes
+        case "null":
+            return AvroPrimitiveType.null
+        case _:
+            raise DataContractException(
+                type="general",
+                name="avro-idl-export",
+                model=type,
+                reason="Unknown Data Contract field type",
+                result="failed",
+                message="Avro IDL type conversion failed."
+                )
+
+def generate_field_types(contract: DataContractSpecification) -> list[AvroFieldType]:
+    result = []
+    for (_, model) in contract.models.items():
+        for (field_name, field) in model.fields.items():
+            result.append(AvroFieldType(
+                name=field_name,
+                description=field.description,
+                type=to_avro_idl_type(field.type)
+            ))
+    return result
+
+def generate_model_types(contract: DataContractSpecification) -> list[AvroModelType]:
+    result = []
+    for (model_name, model) in contract.models.items():
+        result.append(AvroModelType(
+            name=model_name,
+            description=model.description,
+            fields=generate_field_types(contract)
+            ))
+    return result
+
+def model_name_to_identifier(model_name: str):
+    return "".join([word.title() for word in  model_name.split()])
+
+def model_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProtocol:
+    """Convert models into an intermediate representation for later serialization into Avro IDL.
+
+      Each model is converted to a record containing a field for each model field.
+      """
+    inlined_contract = contract.model_copy()
+    inline_definitions_into_data_contract(inlined_contract)
+    return AvroIDLProtocol(name=model_name_to_identifier(contract.info.title),
+                           description=contract.info.description,
+                           model_types=generate_model_types(inlined_contract))
+
+def write_model_type(model: AvroModelType, stream: typing.TextIO):
+    if model.description:
+        stream.write(f"    /** {model.description} */\n")
+    stream.write(f"    record {model.name} {{\n")
+    for field in model.fields:
+        if field.description:
+            stream.write(f"        /** {field.description} */\n")
+        stream.write(f"        {field.type.value} {field.name};\n")
+    stream.write("    }\n")
+
+def to_avro_idl(contract: DataContractSpecification) -> str:
+    stream = StringIO()
+    to_avro_idl_stream(contract, stream)
+    return stream.getvalue()
+
+def to_avro_idl_stream(contract: DataContractSpecification, stream: typing.TextIO):
+    ir = model_to_avro_idl_ir(contract)
+    if contract.info and contract.info.description:
+        stream.write(f"/** {contract.info.description} */\n")
+    stream.write(f"protocol {ir.name} {{\n")
+    for model_type in ir.model_types:
+        write_model_type(model_type, stream)
+    stream.write("}\n")

--- a/datacontract/export/avro_idl_converter.py
+++ b/datacontract/export/avro_idl_converter.py
@@ -1,4 +1,4 @@
-from datacontract.model.data_contract_specification import DataContractSpecification
+from datacontract.model.data_contract_specification import DataContractSpecification, Field
 from datacontract.lint.resolve import inline_definitions_into_data_contract
 from dataclasses import dataclass
 from enum import Enum
@@ -24,101 +24,115 @@ class AvroLogicalType(Enum):
     timestamp_ms = "timestamp_ms"
 
 @dataclass
-class AvroFieldType:
+class AvroPrimitiveField:
     name: str
     description: typing.Optional[str]
     type: typing.Union[AvroPrimitiveType, AvroLogicalType]
 
 @dataclass
+class AvroComplexField:
+    name: str
+    description: typing.Optional[str]
+    subfields: list[typing.Union[AvroPrimitiveField, 'AvroComplexField']]
+
+@dataclass
 class AvroModelType:
     name: str
     description: typing.Optional[str]
-    fields: list[AvroFieldType]
+    fields: list[typing.Union[AvroPrimitiveField, AvroComplexField]]
 
 @dataclass
 class AvroIDLProtocol:
-    name: str
+    name: typing.Optional[str]
     description: typing.Optional[str]
     model_types: list[AvroModelType]
 
+avro_primitive_types = set(["string", "text", "varchar",
+                            "float", "double", "int",
+                            "integer", "long", "bigint",
+                            "boolean", "timestamp_ntz",
+                            "date", "bytes",
+                            "null"])
 
-def to_avro_idl_type(type: str) -> typing.Union[AvroPrimitiveType, AvroLogicalType]:
-    match type:
+def to_avro_primitive_logical_type(field_name: str, field: Field) -> AvroPrimitiveField:
+    result = AvroPrimitiveField(field_name, field.description, AvroPrimitiveType.string)
+    match field.type:
         case "string" | "text" | "varchar":
-            return AvroPrimitiveType.string
+            result.type = AvroPrimitiveType.string
         case "float":
-            return AvroPrimitiveType.float
+            result.type = AvroPrimitiveType.float
         case "double":
-            return AvroPrimitiveType.double
+            result.type = AvroPrimitiveType.double
         case "int" | "integer":
-            return AvroPrimitiveType.int
+            result.type = AvroPrimitiveType.int
         case "long" | "bigint":
-            return AvroPrimitiveType.long
+            result.type = AvroPrimitiveType.long
         case "boolean":
-            return AvroPrimitiveType.boolean
-        case "timestamp" | "timestamp_tz":
-            raise DataContractException(
-                type="general",
-                name="avro-idl-export",
-                model=type,
-                reason="Avro IDL does not support timestamps with timezone.",
-                result="failed",
-                message="Avro IDL type conversion failed."
-            )
+            result.type = AvroPrimitiveType.boolean
         case "timestamp_ntz":
-            return AvroLogicalType.timestamp_ms
+            result.type = AvroLogicalType.timestamp_ms
         case "date":
-            return AvroLogicalType.date
-        case "array":
-            raise DataContractException(
-                type="general",
-                name="avro-idl-export",
-                model=type,
-                reason="Avro IDL export for arrays is not implemented.",
-                result="failed",
-                message="Avro IDL type conversion failed."
-            )
-        case "object":
-            raise DataContractException(
-                type="general",
-                name="avro-idl-export",
-                model=type,
-                reason="Avro IDL export for objects is not implemented.",
-                result="failed",
-                message="Avro IDL type conversion failed."
-            )
-        case "record":
-             raise DataContractException(
-                 type="general",
-                 name="avro-idl-export",
-                 model=type,
-                 reason="Avro IDL export for records is currently not implemented.",
-                 result="failed",
-                 message="Avro IDL type conversion failed."
-             )
+            result.type = AvroLogicalType.date
         case "bytes":
-            return AvroPrimitiveType.bytes
+            result.type = AvroPrimitiveType.bytes
         case "null":
-            return AvroPrimitiveType.null
+            result.type = AvroPrimitiveType.null
         case _:
             raise DataContractException(
                 type="general",
                 name="avro-idl-export",
-                model=type,
-                reason="Unknown Data Contract field type",
+                model=field,
+                reason="Unknown field type {field.type}",
                 result="failed",
                 message="Avro IDL type conversion failed."
+            )
+    return result
+
+def to_avro_idl_type(field_name: str, field: Field) -> typing.Union[AvroPrimitiveField, AvroComplexField]:
+    if field.type in avro_primitive_types:
+        return to_avro_primitive_logical_type(field_name, field)
+    else:
+        match field.type:
+            case "timestamp" | "timestamp_tz":
+                raise DataContractException(
+                    type="general",
+                    name="avro-idl-export",
+                    model=type,
+                    reason="Avro IDL does not support timestamps with timezone.",
+                    result="failed",
+                    message="Avro IDL type conversion failed."
+                )
+            case "array":
+                raise DataContractException(
+                    type="general",
+                    name="avro-idl-export",
+                    model=type,
+                    reason="Avro IDL export for arrays is not implemented.",
+                    result="failed",
+                    message="Avro IDL type conversion failed."
+                )
+            case "object" | "record":
+                return AvroComplexField(
+                    field_name,
+                    field.description,
+                    [to_avro_idl_type(field_name, field) for (field_name, field) in field.fields.items()]
+                )
+            case _:
+                raise DataContractException(
+                    type="general",
+                    name="avro-idl-export",
+                    model=type,
+                    reason="Unknown Data Contract field type",
+                    result="failed",
+                    message="Avro IDL type conversion failed."
                 )
 
-def generate_field_types(contract: DataContractSpecification) -> list[AvroFieldType]:
+
+def generate_field_types(contract: DataContractSpecification) -> list[typing.Union[AvroPrimitiveField, AvroComplexField]]:
     result = []
     for (_, model) in contract.models.items():
         for (field_name, field) in model.fields.items():
-            result.append(AvroFieldType(
-                name=field_name,
-                description=field.description,
-                type=to_avro_idl_type(field.type)
-            ))
+            result.append(to_avro_idl_type(field_name, field))
     return result
 
 def generate_model_types(contract: DataContractSpecification) -> list[AvroModelType]:
@@ -128,32 +142,61 @@ def generate_model_types(contract: DataContractSpecification) -> list[AvroModelT
             name=model_name,
             description=model.description,
             fields=generate_field_types(contract)
-            ))
+        ))
     return result
 
 def model_name_to_identifier(model_name: str):
     return "".join([word.title() for word in  model_name.split()])
 
-def model_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProtocol:
+def contract_to_avro_idl_ir(contract: DataContractSpecification) -> AvroIDLProtocol:
     """Convert models into an intermediate representation for later serialization into Avro IDL.
 
       Each model is converted to a record containing a field for each model field.
       """
     inlined_contract = contract.model_copy()
     inline_definitions_into_data_contract(inlined_contract)
-    return AvroIDLProtocol(name=model_name_to_identifier(contract.info.title),
-                           description=contract.info.description,
+    protocol_name = (model_name_to_identifier(contract.info.title)
+                     if contract.info and contract.info.title
+                     else None)
+    description = (contract.info.description if
+                   contract.info and contract.info.description
+                   else None)
+    return AvroIDLProtocol(name=protocol_name,
+                           description=description,
                            model_types=generate_model_types(inlined_contract))
+
+def write_indent(indent: int, stream: typing.TextIO):
+    stream.write("    " * indent)
+
+def write_field_type(field: typing.Union[AvroPrimitiveField, AvroComplexField],
+                     stream: typing.TextIO, indent=2):
+    if field.description:
+        write_indent(indent, stream)
+        stream.write(f"/** {field.description} */\n")
+    match field:
+        case AvroPrimitiveField(name, _, type):
+            write_indent(indent, stream)
+            stream.write(f"{type.value} {name};\n")
+        case AvroComplexField(name, _, subfields):
+            write_indent(indent, stream)
+            stream.write(f"record {name}_type {{\n")
+            for subfield in subfields:
+                write_field_type(subfield, stream, indent + 1)
+            write_indent(indent, stream)
+            stream.write("}\n")
+            write_indent(indent, stream)
+            stream.write(f"{name}_type {name};\n");
 
 def write_model_type(model: AvroModelType, stream: typing.TextIO):
     if model.description:
-        stream.write(f"    /** {model.description} */\n")
-    stream.write(f"    record {model.name} {{\n")
+        write_indent(1, stream)
+        stream.write(f"/** {model.description} */\n")
+    write_indent(1, stream)
+    stream.write(f"record {model.name} {{\n")
     for field in model.fields:
-        if field.description:
-            stream.write(f"        /** {field.description} */\n")
-        stream.write(f"        {field.type.value} {field.name};\n")
-    stream.write("    }\n")
+        write_field_type(field, stream)
+    write_indent(1, stream)
+    stream.write("}\n")
 
 def to_avro_idl(contract: DataContractSpecification) -> str:
     stream = StringIO()
@@ -161,10 +204,10 @@ def to_avro_idl(contract: DataContractSpecification) -> str:
     return stream.getvalue()
 
 def to_avro_idl_stream(contract: DataContractSpecification, stream: typing.TextIO):
-    ir = model_to_avro_idl_ir(contract)
-    if contract.info and contract.info.description:
+    ir = contract_to_avro_idl_ir(contract)
+    if ir.description:
         stream.write(f"/** {contract.info.description} */\n")
-    stream.write(f"protocol {ir.name} {{\n")
+    stream.write(f"protocol {ir.name or 'Unnamed'} {{\n")
     for model_type in ir.model_types:
         write_model_type(model_type, stream)
     stream.write("}\n")

--- a/datacontract/lint/resolve.py
+++ b/datacontract/lint/resolve.py
@@ -49,7 +49,8 @@ def resolve_data_contract_from_location(
 def inline_definitions_into_data_contract(spec: DataContractSpecification):
     for model in spec.models.values():
         for field in model.fields.values():
-            if field.ref is None:
+            # If ref_obj is not empty, we've already inlined definitions.
+            if not field.ref and not field.ref_obj:
                 continue
 
             definition = resolve_ref(field.ref, spec.definitions)

--- a/datacontract/model/data_contract_specification.py
+++ b/datacontract/model/data_contract_specification.py
@@ -83,6 +83,7 @@ class Field(pyd.BaseModel):
     enum: List[str] = []
     tags: List[str] = []
     fields: Dict[str, 'Field'] = {}
+    items: 'Field' = None
 
 
 class Model(pyd.BaseModel):

--- a/tests/test_export_avro_idl.py
+++ b/tests/test_export_avro_idl.py
@@ -79,7 +79,40 @@ def test_avro_idl_complex_type():
                 /** Primitive field */
                 string nested_field_1;
             }
+            /** Complex field */
             test_field_type test_field;
+        }
+    }
+    """).strip()
+    assert to_avro_idl(contract).strip() == expected
+
+def test_avro_idl_array_type():
+    contract = spec.DataContractSpecification(
+        models={
+            "test_model": spec.Model(
+                description="Test model",
+                fields={
+                    "test_field": spec.Field(
+                        type="array",
+                        description="Array field",
+                        items=spec.Field(
+                            type="record",
+                            description="Record field",
+                            fields={
+                                "nested_field_1": spec.Field(
+                                    type="text",
+                                    description="Primitive field")}))})})
+    expected = dedent("""
+    protocol Unnamed {
+        /** Test model */
+        record test_model {
+            /** Record field */
+            record test_field_type {
+                /** Primitive field */
+                string nested_field_1;
+            }
+            /** Array field */
+            array<test_field_type> test_field;
         }
     }
     """).strip()

--- a/tests/test_export_avro_idl.py
+++ b/tests/test_export_avro_idl.py
@@ -1,0 +1,56 @@
+from typer.testing import CliRunner
+from datacontract.export.avro_idl_converter import model_to_avro_idl_ir,\
+    AvroPrimitiveType, AvroFieldType, AvroModelType,\
+    AvroIDLProtocol, to_avro_idl
+from datacontract.lint.resolve import resolve_data_contract_from_location
+from datacontract.cli import app
+from textwrap import dedent
+
+def test_ir():
+    contract = resolve_data_contract_from_location("examples/lint/valid_datacontract_references.yaml",
+                                                   inline_definitions=True)
+    expected = AvroIDLProtocol(
+        name="OrdersLatest",
+        description="Successful customer orders in the webshop.\n"
+        "All orders since 2020-01-01.\n"
+        "Orders with their line items are in their current state (no history included).\n",
+        model_types=[
+            AvroModelType(
+                "orders",
+                "One record per order. Includes cancelled and deleted orders.",
+                [AvroFieldType(
+                    "order_id",
+                    "An internal ID that identifies an order in the online shop.",
+                    type=AvroPrimitiveType.string)]),
+        ])
+    assert model_to_avro_idl_ir(contract) == expected
+
+def test_avro_idl_str():
+    contract = resolve_data_contract_from_location("examples/lint/valid_datacontract_references.yaml",
+                                                   inline_definitions=True)
+    expected = dedent(
+        """
+          /** Successful customer orders in the webshop.
+          All orders since 2020-01-01.
+          Orders with their line items are in their current state (no history included).
+           */
+          protocol OrdersLatest {
+              /** One record per order. Includes cancelled and deleted orders. */
+              record orders {
+                  /** An internal ID that identifies an order in the online shop. */
+                  string order_id;
+              }
+          }
+        """).strip()
+    assert to_avro_idl(contract).strip() == expected
+
+def test_avro_idl_cli_export():
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "export",
+        "./examples/lint/valid_datacontract_references.yaml",
+        "--format", "avro-idl"
+    ])
+    if result.exit_code:
+        print(result.output)
+    assert result.exit_code == 0

--- a/tests/test_export_avro_idl.py
+++ b/tests/test_export_avro_idl.py
@@ -1,5 +1,5 @@
 from typer.testing import CliRunner
-from datacontract.export.avro_idl_converter import contract_to_avro_idl_ir,\
+from datacontract.export.avro_idl_converter import _contract_to_avro_idl_ir,\
     AvroPrimitiveType, AvroPrimitiveField, AvroModelType,\
     AvroIDLProtocol, to_avro_idl
 from datacontract.lint.resolve import resolve_data_contract_from_location
@@ -22,10 +22,11 @@ def test_ir():
                 "One record per order. Includes cancelled and deleted orders.",
                 [AvroPrimitiveField(
                     "order_id",
+                    True,
                     "An internal ID that identifies an order in the online shop.",
                     type=AvroPrimitiveType.string)]),
         ])
-    assert contract_to_avro_idl_ir(contract) == expected
+    assert _contract_to_avro_idl_ir(contract) == expected
 
 def test_avro_idl_str():
     contract = resolve_data_contract_from_location("examples/lint/valid_datacontract_references.yaml",
@@ -65,6 +66,7 @@ def test_avro_idl_complex_type():
                 fields={
                     "test_field": spec.Field(
                         type="object",
+                        required=True,
                         description="Complex field",
                         fields={
                             "nested_field_1": spec.Field(
@@ -77,7 +79,7 @@ def test_avro_idl_complex_type():
             /** Complex field */
             record test_field_type {
                 /** Primitive field */
-                string nested_field_1;
+                string? nested_field_1;
             }
             /** Complex field */
             test_field_type test_field;
@@ -109,10 +111,10 @@ def test_avro_idl_array_type():
             /** Record field */
             record test_field_type {
                 /** Primitive field */
-                string nested_field_1;
+                string? nested_field_1;
             }
             /** Array field */
-            array<test_field_type> test_field;
+            array<test_field_type?>? test_field;
         }
     }
     """).strip()


### PR DESCRIPTION
Basic implementation of #80.

Currently does not support complex objects as field types. Generates a protocol for the data
contract, with one record per model containing the fields. Descriptions are included via
documentation comments. Definitions are inlined.
