### PR TITLE
Add great expectation option for the export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added export format **great-expectations**: `datacontract export --format great-expectations`  
 
 
 

--- a/README.md
+++ b/README.md
@@ -440,22 +440,34 @@ datacontract export --format dbt
 
 Available export options:
 
-| Type               | Description                                             | Status |
-|--------------------|---------------------------------------------------------|--------|
-| `jsonschema`       | Export to JSON Schema                                   | ✅      | 
-| `odcs`             | Export to Open Data Contract Standard (ODCS)            | ✅      | 
-| `sodacl`           | Export to SodaCL quality checks in YAML format          | ✅      |
-| `dbt`              | Export to dbt models in YAML format                     | ✅      |
-| `dbt-sources`      | Export to dbt sources in YAML format                    | ✅      |
-| `dbt-staging-sql`  | Export to dbt staging SQL models                        | ✅      |
-| `rdf`              | Export data contract to RDF representation in N3 format | ✅      |
-| `avro`             | Export to AVRO models                                   | ✅      |
-| `protobuf`         | Export to Protobuf                                      | ✅      |
-| `terraform`        | Export to terraform resources                           | ✅      |
-| `sql`              | Export to SQL DDL                                       | ✅      |
-| `sql-query`        | Export to SQL Query                                     | ✅      |
-| `pydantic`         | Export to pydantic models                               | TBD    |
-| Missing something? | Please create an issue on GitHub                        | TBD    |
+| Type                 | Description                                             | Status |
+|----------------------|---------------------------------------------------------|--------|
+| `jsonschema`         | Export to JSON Schema                                   | ✅      | 
+| `odcs`               | Export to Open Data Contract Standard (ODCS)            | ✅      | 
+| `sodacl`             | Export to SodaCL quality checks in YAML format          | ✅      |
+| `dbt`                | Export to dbt models in YAML format                     | ✅      |
+| `dbt-sources`        | Export to dbt sources in YAML format                    | ✅      |
+| `dbt-staging-sql`    | Export to dbt staging SQL models                        | ✅      |
+| `rdf`                | Export data contract to RDF representation in N3 format | ✅      |
+| `avro`               | Export to AVRO models                                   | ✅      |
+| `protobuf`           | Export to Protobuf                                      | ✅      |
+| `terraform`          | Export to terraform resources                           | ✅      |
+| `sql`                | Export to SQL DDL                                       | ✅      |
+| `sql-query`          | Export to SQL Query                                     | ✅      |
+| `great-expectations` | Export to Great Expectations Suites in JSON Format      | ✅      |
+| `pydantic`           | Export to pydantic models                               | TBD    |
+| Missing something?   | Please create an issue on GitHub                        | TBD    |
+
+#### Great Expectations
+The export function transforms a specified data contract into a comprehensive Great Expectations JSON suite. 
+If the contract includes multiple models, you need to specify the names of the model you wish to export.
+```shell
+datacontract  export datacontract.yaml --format great-expectations --model orders 
+```
+The export creates a list of expectations by utilizing:
+
+- The data from the Model definition with a fixed mapping
+- The expectations provided in the quality field for each model (find here the expectations gallery https://greatexpectations.io/expectations/)
 
 #### RDF
 

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -133,7 +133,7 @@ class ExportFormat(str, Enum):
     rdf = "rdf"
     avro = "avro"
     protobuf = "protobuf"
-    great_expectations="great-expectations"
+    great_expectations = "great-expectations"
     terraform = "terraform"
     avro_idl = "avro-idl"
     sql = "sql"

--- a/datacontract/cli.py
+++ b/datacontract/cli.py
@@ -133,6 +133,7 @@ class ExportFormat(str, Enum):
     rdf = "rdf"
     avro = "avro"
     protobuf = "protobuf"
+    great_expectations="great-expectations"
     terraform = "terraform"
     avro_idl = "avro-idl"
     sql = "sql"

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -391,8 +391,29 @@ class DataContract:
                     raise RuntimeError(f"Model {model_name} not found in the data contract. Available models: {model_names}")
 
                 return to_sql_query(data_contract, model_name, model_value, server_type)
+
         if export_format == "great-expectations":
-            return to_great_expectations(data_contract)
+            if data_contract.models is None:
+                raise RuntimeError(f"Export to {export_format} requires models in the data contract.")
+
+            model_names = list(data_contract.models.keys())
+
+            if model == "all":
+                if len(data_contract.models.items()) != 1:
+                    raise RuntimeError(f"Export to {export_format} is model specific. Specify the model via --model "
+                                       f"$MODEL_NAME. Available models: {model_names}")
+
+                model_name, model_value = next(iter(data_contract.models.items()))
+                return to_great_expectations(data_contract, model_name)
+            else:
+                model_name = model
+                model_value = data_contract.models.get(model_name)
+                if model_value is None:
+                    raise RuntimeError(f"Model {model_name} not found in the data contract. "
+                                        f"Available models: {model_names}")
+
+                return to_great_expectations(data_contract, model_name)
+
         else:
             print(f"Export format {export_format} not supported.")
             return ""

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -18,6 +18,10 @@ from datacontract.export.dbt_converter import to_dbt_models_yaml, \
 from datacontract.export.jsonschema_converter import to_jsonschema, to_jsonschema_json
 from datacontract.export.odcs_converter import to_odcs_yaml
 from datacontract.export.protobuf_converter import to_protobuf
+from datacontract.export.great_expectations_converter import to_great_expectations
+
+
+from datacontract.export.rdf_converter import to_rdf, to_rdf_n3
 from datacontract.export.rdf_converter import to_rdf_n3
 from datacontract.export.sodacl_converter import to_sodacl_yaml
 from datacontract.imports.avro_importer import import_avro
@@ -389,6 +393,8 @@ class DataContract:
                     raise RuntimeError(f"Model {model_name} not found in the data contract. Available models: {model_names}")
 
                 return to_sql_query(data_contract, model_name, model_value, server_type)
+        if export_format == "great-expectations":
+            return to_great_expectations(data_contract)
         else:
             print(f"Export format {export_format} not supported.")
             return ""

--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -19,8 +19,6 @@ from datacontract.export.jsonschema_converter import to_jsonschema, to_jsonschem
 from datacontract.export.odcs_converter import to_odcs_yaml
 from datacontract.export.protobuf_converter import to_protobuf
 from datacontract.export.great_expectations_converter import to_great_expectations
-
-
 from datacontract.export.rdf_converter import to_rdf, to_rdf_n3
 from datacontract.export.rdf_converter import to_rdf_n3
 from datacontract.export.sodacl_converter import to_sodacl_yaml

--- a/datacontract/export/great_expectations_converter.py
+++ b/datacontract/export/great_expectations_converter.py
@@ -31,7 +31,6 @@ def to_suite(model_key: str, expectations: List[Dict[str, Any]], ) -> Dict[str, 
         "expectation_suite_name": "user-defined." + model_key,
         "expectations": expectations,
         "meta": {
-            "great_expectations_version": "0.18.9"
         }
     }
 

--- a/datacontract/export/great_expectations_converter.py
+++ b/datacontract/export/great_expectations_converter.py
@@ -1,0 +1,135 @@
+import json
+from typing import Dict
+
+import yaml
+
+from datacontract.model.data_contract_specification import \
+    DataContractSpecification, Field, Quality
+
+
+def to_great_expectations(data_contract_spec: DataContractSpecification):
+    great_expectation_jsons = {}
+    expectations = []
+    quality_checks = get_quality_checks(data_contract_spec.quality)
+    for model_key, model_value in data_contract_spec.models.items():
+        expectations.extend(model_to_expectations(model_value.fields))
+        expectations.extend(checks_to_expectations(quality_checks, model_key))
+        great_expectation_json = to_suite(model_key, expectations)
+        great_expectation_jsons[model_key] = great_expectation_json
+
+    return great_expectation_jsons
+
+
+def to_suite(model_key: str, expectations: [], ) -> dict:
+    return {
+        "data_asset_type": "null",
+        "expectation_suite_name": "user-defined." + model_key,
+        "expectations": expectations,
+        "meta": {
+            "great_expectations_version": "0.17.23"
+        }
+    }
+
+
+def model_to_expectations(fields: Dict[str, Field]) -> list:
+    expectations = []
+    add_column_order_exp(fields, expectations)
+    for field_name, field in fields.items():
+        add_field_expectations(field_name, field, expectations)
+    return expectations
+
+
+def add_field_expectations(field_name, field: Field, expectations: []) -> dict:
+    if field.type is not None:
+        expectations.append(to_column_types_exp(field_name, field.type))
+    if field.unique is not None:
+        expectations.append(to_column_unique_exp(field_name))
+    if field.maxLength is not None or field.minLength is not None:
+        expectations.append(to_column_length_exp(field_name, field.minLength, field.maxLength))
+    if field.minimum is not None or field.maximum is not None:
+        expectations.append(to_column_min_max_exp(field_name, field.minimum, field.maximum))
+
+    # TODO: all constraints
+    return expectations
+
+
+def add_column_order_exp(fields: Dict[str, Field], expectations: []):
+    expectations.append({"expectation_type": "expect_table_columns_to_match_ordered_list",
+                         "kwargs": {
+                             "column_list": list(fields.keys())
+                         },
+                         "meta": {}
+                         })
+
+
+def to_column_types_exp(field_name, field_type) -> dict:
+    return {
+        "expectation_type": "expect_column_values_to_be_of_type",
+        "kwargs": {
+            "column": field_name,
+            "type_": field_type
+        },
+        "meta": {}
+    }
+
+
+def to_column_unique_exp(field_name) -> dict:
+    return {
+        "expectation_type": "expect_column_values_to_be_unique",
+        "kwargs": {
+            "column": field_name
+        },
+        "meta": {}
+    }
+
+
+def to_column_length_exp(field_name, min_length, max_length) -> dict:
+    return {
+        "expectation_type": "expect_column_value_lengths_to_be_between",
+        "kwargs": {
+            "column": field_name,
+            "min_value": min_length,
+            "max_value": max_length
+        },
+        "meta": {}
+    }
+
+
+def to_column_min_max_exp(field_name, minimum, maximum) -> dict:
+    return {
+        "expectation_type": "expect_column_values_to_be_between",
+        "kwargs": {
+            "column": field_name,
+            "min_value": minimum,
+            "max_value": maximum
+        },
+        "meta": {}
+    }
+
+
+def get_quality_checks(quality: Quality) -> dict:
+    if quality is None:
+        return {}
+    if quality.type is None:
+        return {}
+    if quality.type.lower() != "great-expectations":
+        return {}
+    if isinstance(quality.specification, str):
+        quality_specification = yaml.safe_load(quality.specification)
+    else:
+        quality_specification = quality.specification
+    return quality_specification
+
+
+def checks_to_expectations(quality_checks: {}, model_key: str) -> []:
+    if quality_checks is None or model_key not in quality_checks:
+        return []
+
+    model_quality_checks = quality_checks[model_key]
+
+    if model_quality_checks is None:
+        return []
+
+    if isinstance(model_quality_checks, str):
+        expectation_list = json.loads(model_quality_checks)
+        return expectation_list

--- a/datacontract/lint/linters/quality_schema_linter.py
+++ b/datacontract/lint/linters/quality_schema_linter.py
@@ -30,6 +30,11 @@ class QualityUsesSchemaLinter(Linter):
         return LinterResult().with_warning(
             "Linting montecarlo checks is not currently implemented")
 
+    def lint_great_expectations(self, check, models: dict[str, Model]) ->\
+            LinterResult:
+        return LinterResult().with_warning(
+            "Linting great expectations checks is not currently implemented")
+
     def lint_implementation(self, contract: DataContractSpecification) ->\
             LinterResult:
         result = LinterResult()
@@ -50,6 +55,9 @@ class QualityUsesSchemaLinter(Linter):
             case "montecarlo":
                 result = result.combine(
                     self.lint_montecarlo(check_specification, models))
+            case "great-expectations":
+                result = result.combine(
+                    self.lint_great_expectations(check_specification, models))
             case _:
                 result = result.with_warning("Can't lint quality check "
                                              f"with type '{check.type}'")

--- a/tests/examples/great-expectations/datacontract.yaml
+++ b/tests/examples/great-expectations/datacontract.yaml
@@ -1,0 +1,26 @@
+dataContractSpecification: 0.9.1
+models:
+  orders:
+    description: test
+    fields:
+      order_id:
+        type: string
+        required: true
+      processed_timestamp:
+        type: timestamp
+        required: true
+quality:
+  type: great-expectations
+  specification:
+    orders: |-
+      [
+          {
+              "expectation_type": "expect_table_row_count_to_be_between",
+              "kwargs": {
+                  "min_value": 10
+              },
+              "meta": {
+      
+              }
+          }
+      ]

--- a/tests/examples/great-expectations/datacontract.yaml
+++ b/tests/examples/great-expectations/datacontract.yaml
@@ -1,4 +1,12 @@
 dataContractSpecification: 0.9.1
+info:
+  title: Orders Unit Test
+  version: 1.0.0
+  owner: checkout
+  description: The orders data contract
+  contact:
+    email: team-orders@example.com
+    url: https://wiki.example.com/teams/checkout
 models:
   orders:
     description: test

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -117,7 +117,6 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
             }
         ],
         "meta": {
-            "great_expectations_version": "0.17.23"
         }
     }
     result = to_great_expectations(data_contract_basic)
@@ -242,7 +241,6 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
             }
         ],
         "meta": {
-            "great_expectations_version": "0.17.23"
         }
     }
 
@@ -359,7 +357,6 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
             }
         ],
         "meta": {
-            "great_expectations_version": "0.17.23"
         }
     }
     result = to_great_expectations(data_contract_complex)
@@ -419,7 +416,6 @@ def test_to_great_expectation_quality(data_contract_great_expectations: DataCont
             }
         ],
         "meta": {
-            "great_expectations_version": "0.17.23"
         }
     }
     result = to_great_expectations(data_contract_great_expectations)

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -1,0 +1,423 @@
+import logging
+import logging
+import os
+import sys
+
+from typer.testing import CliRunner
+
+from datacontract.cli import app
+from datacontract.export.great_expectations_converter import to_great_expectations
+from datacontract.model.data_contract_specification import \
+    DataContractSpecification
+
+logging.basicConfig(level=logging.DEBUG, force=True)
+
+
+def test_cli():
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "export",
+        "./examples/export/datacontract.yaml",
+        "--format", "jsonschema"
+    ])
+    assert result.exit_code == 0
+
+
+def test_to_great_expectation():
+    data_contract_file = "./examples/export/datacontract.yaml"
+    file_content = read_file(data_contract_file=data_contract_file)
+    data_contract = DataContractSpecification.from_string(file_content)
+    expected_json_suite = {
+        "data_asset_type": "null",
+        "expectation_suite_name": "user-defined.orders",
+        "expectations": [
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "order_id",
+                        "order_total",
+                        "order_status"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_id",
+                    "type_": "varchar"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {
+                    "column": "order_id"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_value_lengths_to_be_between",
+                "kwargs": {
+                    "column": "order_id",
+                    "min_value": 8,
+                    "max_value": 10
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_total",
+                    "type_": "bigint"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": {
+                    "column": "order_total",
+                    "min_value": 0,
+                    "max_value": 1000000
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_status",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            }
+        ],
+        "meta": {
+            "great_expectations_version": "0.17.23"
+        }
+    }
+    result = to_great_expectations(data_contract)
+    assert result["orders"] == expected_json_suite
+
+
+def test_to_great_expectation_complex():
+    data_contract_file = "./examples/export/rdf/datacontract-complex.yaml"
+    file_content = read_file(data_contract_file=data_contract_file)
+    data_contract = DataContractSpecification.from_string(file_content)
+    expected_orders = {
+        "data_asset_type": "null",
+        "expectation_suite_name": "user-defined.orders",
+        "expectations": [
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "order_id",
+                        "order_timestamp",
+                        "order_total",
+                        "customer_id",
+                        "customer_email_address"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {
+                    "column": "order_id"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_timestamp",
+                    "type_": "timestamp"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_total",
+                    "type_": "long"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "customer_id",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_value_lengths_to_be_between",
+                "kwargs": {
+                    "column": "customer_id",
+                    "min_value": 10,
+                    "max_value": 20
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "customer_email_address",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "lines_item_id",
+                        "order_id",
+                        "sku"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "lines_item_id",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {
+                    "column": "lines_item_id"
+                },
+                "meta": {
+
+                }
+            }
+        ],
+        "meta": {
+            "great_expectations_version": "0.17.23"
+        }
+    }
+
+    expected_line_items = {
+        "data_asset_type": "null",
+        "expectation_suite_name": "user-defined.line_items",
+        "expectations": [
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "order_id",
+                        "order_timestamp",
+                        "order_total",
+                        "customer_id",
+                        "customer_email_address"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {
+                    "column": "order_id"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_timestamp",
+                    "type_": "timestamp"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_total",
+                    "type_": "long"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "customer_id",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_value_lengths_to_be_between",
+                "kwargs": {
+                    "column": "customer_id",
+                    "min_value": 10,
+                    "max_value": 20
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "customer_email_address",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "lines_item_id",
+                        "order_id",
+                        "sku"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "lines_item_id",
+                    "type_": "text"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {
+                    "column": "lines_item_id"
+                },
+                "meta": {
+
+                }
+            }
+        ],
+        "meta": {
+            "great_expectations_version": "0.17.23"
+        }
+    }
+    result = to_great_expectations(data_contract)
+    assert result["orders"] == expected_orders
+    assert result["line_items"] == expected_line_items
+
+
+def test_to_great_expectation_quality():
+    data_contract_file = "./examples/great-expectations/datacontract.yaml"
+    file_content = read_file(data_contract_file=data_contract_file)
+    data_contract = DataContractSpecification.from_string(file_content)
+    expected_json_suite = {
+        "data_asset_type": "null",
+        "expectation_suite_name": "user-defined.orders",
+        "expectations": [
+            {
+                "expectation_type": "expect_table_columns_to_match_ordered_list",
+                "kwargs": {
+                    "column_list": [
+                        "order_id",
+                        "processed_timestamp"
+                    ]
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "order_id",
+                    "type_": "string"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_column_values_to_be_of_type",
+                "kwargs": {
+                    "column": "processed_timestamp",
+                    "type_": "timestamp"
+                },
+                "meta": {
+
+                }
+            },
+            {
+                "expectation_type": "expect_table_row_count_to_be_between",
+                "kwargs": {
+                    "min_value": 10
+                },
+                "meta": {
+
+                }
+            }
+        ],
+        "meta": {
+            "great_expectations_version": "0.17.23"
+        }
+    }
+    result = to_great_expectations(data_contract)
+    assert result["orders"] == expected_json_suite
+
+
+def read_file(data_contract_file):
+    if not os.path.exists(data_contract_file):
+        print(f"The file '{data_contract_file}' does not exist.")
+        sys.exit(1)
+    with open(data_contract_file, 'r') as file:
+        file_content = file.read()
+    return file_content

--- a/tests/test_export_great_expectations.py
+++ b/tests/test_export_great_expectations.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import pytest
@@ -16,9 +17,36 @@ def test_cli():
     result = runner.invoke(app, [
         "export",
         "./examples/export/datacontract.yaml",
-        "--format", "jsonschema"
+        "--format", "great-expectations"
     ])
     assert result.exit_code == 0
+
+
+def test_cli_multi_models():
+    """
+    Test with 2 model definitions in the contract with the model parameter
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "export",
+        "./examples/export/rdf/datacontract-complex.yaml",
+        "--format", "great-expectations",
+        "--model", "orders"
+    ])
+    assert result.exit_code == 0
+
+
+def test_cli_multi_models_failed():
+    """
+    Test with 2 model definitions in the contract without the model parameter
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, [
+        "export",
+        "./examples/export/rdf/datacontract-complex.yaml",
+        "--format", "great-expectations"
+    ])
+    assert result.exit_code == 1
 
 
 @pytest.fixture
@@ -39,7 +67,7 @@ def data_contract_great_expectations() -> DataContractSpecification:
 def test_to_great_expectation(data_contract_basic: DataContractSpecification):
     expected_json_suite = {
         "data_asset_type": "null",
-        "expectation_suite_name": "user-defined.orders",
+        "expectation_suite_name": "user-defined.orders.1.0.0",
         "expectations": [
             {
                 "expectation_type": "expect_table_columns_to_match_ordered_list",
@@ -50,9 +78,7 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                         "order_status"
                     ]
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_values_to_be_of_type",
@@ -60,18 +86,14 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                     "column": "order_id",
                     "type_": "varchar"
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_values_to_be_unique",
                 "kwargs": {
                     "column": "order_id"
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_value_lengths_to_be_between",
@@ -80,9 +102,7 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                     "min_value": 8,
                     "max_value": 10
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_values_to_be_of_type",
@@ -90,9 +110,7 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                     "column": "order_total",
                     "type_": "bigint"
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_values_to_be_between",
@@ -101,9 +119,7 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                     "min_value": 0,
                     "max_value": 1000000
                 },
-                "meta": {
-
-                }
+                "meta": {}
             },
             {
                 "expectation_type": "expect_column_values_to_be_of_type",
@@ -111,16 +127,14 @@ def test_to_great_expectation(data_contract_basic: DataContractSpecification):
                     "column": "order_status",
                     "type_": "text"
                 },
-                "meta": {
-
-                }
+                "meta": {}
             }
         ],
-        "meta": {
-        }
+        "meta": {}
     }
-    result = to_great_expectations(data_contract_basic)
-    assert result["orders"] == expected_json_suite
+
+    result_orders = to_great_expectations(data_contract_basic, "orders")
+    assert result_orders == json.dumps(expected_json_suite, indent=2)
 
 
 def test_to_great_expectation_complex(data_contract_complex: DataContractSpecification):
@@ -130,7 +144,7 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
 
     expected_orders = {
         "data_asset_type": "null",
-        "expectation_suite_name": "user-defined.orders",
+        "expectation_suite_name": "user-defined.orders.1.0.0",
         "expectations": [
             {
                 "expectation_type": "expect_table_columns_to_match_ordered_list",
@@ -202,38 +216,6 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
                 "kwargs": {
                     "column": "customer_email_address",
                     "type_": "text"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_table_columns_to_match_ordered_list",
-                "kwargs": {
-                    "column_list": [
-                        "lines_item_id",
-                        "order_id",
-                        "sku"
-                    ]
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "lines_item_id",
-                    "type_": "text"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_unique",
-                "kwargs": {
-                    "column": "lines_item_id"
                 },
                 "meta": {
 
@@ -246,83 +228,8 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
 
     expected_line_items = {
         "data_asset_type": "null",
-        "expectation_suite_name": "user-defined.line_items",
+        "expectation_suite_name": "user-defined.line_items.1.0.0",
         "expectations": [
-            {
-                "expectation_type": "expect_table_columns_to_match_ordered_list",
-                "kwargs": {
-                    "column_list": [
-                        "order_id",
-                        "order_timestamp",
-                        "order_total",
-                        "customer_id",
-                        "customer_email_address"
-                    ]
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_unique",
-                "kwargs": {
-                    "column": "order_id"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "order_timestamp",
-                    "type_": "timestamp"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "order_total",
-                    "type_": "long"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "customer_id",
-                    "type_": "text"
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_value_lengths_to_be_between",
-                "kwargs": {
-                    "column": "customer_id",
-                    "min_value": 10,
-                    "max_value": 20
-                },
-                "meta": {
-
-                }
-            },
-            {
-                "expectation_type": "expect_column_values_to_be_of_type",
-                "kwargs": {
-                    "column": "customer_email_address",
-                    "type_": "text"
-                },
-                "meta": {
-
-                }
-            },
             {
                 "expectation_type": "expect_table_columns_to_match_ordered_list",
                 "kwargs": {
@@ -359,9 +266,12 @@ def test_to_great_expectation_complex(data_contract_complex: DataContractSpecifi
         "meta": {
         }
     }
-    result = to_great_expectations(data_contract_complex)
-    assert result["orders"] == expected_orders
-    assert result["line_items"] == expected_line_items
+    result_orders = to_great_expectations(data_contract_complex, "orders")
+    assert result_orders == json.dumps(expected_orders, indent=2)
+
+    result_line_items = to_great_expectations(data_contract_complex, "line_items")
+
+    assert result_line_items == json.dumps(expected_line_items, indent=2)
 
 
 def test_to_great_expectation_quality(data_contract_great_expectations: DataContractSpecification):
@@ -371,7 +281,7 @@ def test_to_great_expectation_quality(data_contract_great_expectations: DataCont
 
     expected_json_suite = {
         "data_asset_type": "null",
-        "expectation_suite_name": "user-defined.orders",
+        "expectation_suite_name": "user-defined.orders.1.0.0",
         "expectations": [
             {
                 "expectation_type": "expect_table_columns_to_match_ordered_list",
@@ -418,5 +328,5 @@ def test_to_great_expectation_quality(data_contract_great_expectations: DataCont
         "meta": {
         }
     }
-    result = to_great_expectations(data_contract_great_expectations)
-    assert result["orders"] == expected_json_suite
+    result = to_great_expectations(data_contract_great_expectations, "orders")
+    assert result == json.dumps(expected_json_suite, indent=2)


### PR DESCRIPTION
Hello, 

I create this PR to add the great expectation option for the export command. 
The export generates a dictionary with a great expectation suite for each model in the contract. 
The export generates the list of expectations based on :
- the information in the Model definition with a hardcoded mapping 
- the list of expectation filled in the quality field for each model