### PR TITLE
First implementation of pydantic model export.

### DIFF
--- a/datacontract/data_contract.py
+++ b/datacontract/data_contract.py
@@ -22,6 +22,7 @@ from datacontract.export.great_expectations_converter import \
 from datacontract.export.jsonschema_converter import to_jsonschema_json
 from datacontract.export.odcs_converter import to_odcs_yaml
 from datacontract.export.protobuf_converter import to_protobuf
+from datacontract.export.pydantic_converter import to_pydantic_model_str
 from datacontract.export.rdf_converter import to_rdf_n3
 from datacontract.export.sodacl_converter import to_sodacl_yaml
 from datacontract.export.sql_converter import to_sql_ddl, to_sql_query
@@ -434,7 +435,8 @@ class DataContract:
                     )
 
                 return to_great_expectations(data_contract, model_name)
-
+        if export_format == "pydantic-model":
+            return to_pydantic_model_str(data_contract)
         else:
             print(f"Export format {export_format} not supported.")
             return ""

--- a/datacontract/export/pydantic_converter.py
+++ b/datacontract/export/pydantic_converter.py
@@ -1,0 +1,131 @@
+import datacontract.model.data_contract_specification as spec
+import typing
+import ast
+
+
+def to_pydantic_model_str(contract: spec.DataContractSpecification) -> str:
+    classdefs = [generate_model_class(model_name, model) for (model_name, model) in contract.models.items()]
+    result = ast.unparse(with_imports(classdefs))
+    return result
+
+def with_imports(classdefs: list[ast.ClassDef]) -> ast.Module:
+    return ast.Module(body=[
+        ast.Import(
+            names=[ast.Name("datetime", ctx=ast.Load()),
+                   ast.Name("typing", ctx=ast.Load()),
+                   ast.Name("pydantic", ctx=ast.Load())]),
+        *classdefs],
+        type_ignores=[])
+
+def optional_of(node) -> ast.Subscript:
+    return ast.Subscript(
+        value=ast.Attribute(
+            ast.Name(id="typing", ctx=ast.Load()),
+            attr="Optional",
+            ctx=ast.Load()),
+        slice=node)
+
+def list_of(node) -> ast.Subscript:
+    return ast.Subscript(
+        value=ast.Name(id="list", ctx=ast.Load()),
+        slice=node)
+
+def product_of(nodes: list[typing.Any]) -> ast.Subscript:
+    return ast.Subscript(
+        value=ast.Attribute(
+            value=ast.Name(id="typing", ctx=ast.Load()),
+            attr="Product",
+            ctx=ast.Load()),
+        slice=ast.Tuple(nodes, ctx=ast.Load())
+    )
+
+
+type_annotation_type = typing.Union[ast.Name, ast.Attribute, ast.Constant, ast.Subscript]
+
+def constant_field_annotation(field_name: str, field: spec.Field)\
+        -> tuple[type_annotation_type,
+                 typing.Optional[ast.ClassDef]]:
+    match field.type:
+        case "string"|"text"|"varchar":
+            return (ast.Name("str", ctx=ast.Load()), None)
+        case "number", "decimal", "numeric":
+            # Either integer or float in specification,
+            # so we use float.
+            return (ast.Name("float", ctx=ast.Load()), None)
+        case "int" | "integer" | "long" | "bigint":
+            return (ast.Name("int", ctx=ast.Load()), None)
+        case "float" | "double":
+            return (ast.Name("float", ctx=ast.Load()), None)
+        case "boolean":
+            return (ast.Name("bool", ctx=ast.Load()), None)
+        case "timestamp" | "timestamp_tz" | "timestamp_ntz":
+            return (ast.Attribute(
+                value=ast.Name(id="datetime", ctx=ast.Load()),
+                attr="datetime"), None)
+        case "date":
+            return (ast.Attribute(
+                value=ast.Name(id="datetime", ctx=ast.Load()),
+                attr="date"), None)
+        case "bytes":
+            return (ast.Name("bytes", ctx=ast.Load()), None)
+        case "null":
+            return (ast.Constant("None"), None)
+        case "array":
+            (annotated_type, new_class) = type_annotation(field_name, field.items)
+            return (list_of(annotated_type), new_class)
+        case "object" | "record" | "struct":
+            classdef = generate_field_class(field_name.capitalize(), field)
+            return (ast.Name(field_name.capitalize(), ctx=ast.Load()), classdef)
+        case _:
+            raise RuntimeError(f"Unsupported field type {field.type}.")
+
+
+def type_annotation(field_name: str, field: spec.Field) -> tuple[type_annotation_type, typing.Optional[ast.ClassDef]]:
+    if field.required:
+        return constant_field_annotation(field_name, field)
+    else:
+        (annotated_type, new_classes) = constant_field_annotation(field_name, field)
+        return (optional_of(annotated_type), new_classes)
+
+def field_definitions(fields: dict[str, spec.Field]) ->\
+        tuple[list[ast.AnnAssign],
+              list[ast.ClassDef]]:
+    annotations = []
+    classes = []
+    for (field_name, field) in fields.items():
+        (ann, new_class) = type_annotation(field_name, field)
+        annotations.append(
+            ast.AnnAssign(
+                target=ast.Name(id=field_name, ctx=ast.Store()),
+                annotation=ann,
+                simple=1))
+        if new_class:
+            classes.append(new_class)
+    return (annotations, classes)
+
+def generate_field_class(field_name: str, field: spec.Field) -> ast.ClassDef:
+    assert(field.type in set(["object", "record", "struct"]))
+    (annotated_type, new_classes) = field_definitions(field.fields)
+    return ast.ClassDef(
+        name=field_name,
+        bases=[ast.Attribute(value=ast.Name(id="pydantic", ctx=ast.Load()),
+                             attr="BaseModel",
+                             ctx=ast.Load())],
+        body=[
+            *new_classes,
+            *annotated_type],
+        keywords=[],
+        decorator_list=[])
+
+
+def generate_model_class(name: str, model_definition: spec.Model) -> ast.ClassDef:
+    (field_assignments, nested_classes) = field_definitions(model_definition.fields)
+    result = ast.ClassDef(
+        name=name.capitalize(),
+        bases=[ast.Attribute(value=ast.Name(id="pydantic", ctx=ast.Load()),
+                             attr="BaseModel",
+                             ctx=ast.Load())],
+        body=[*nested_classes, *field_assignments],
+        keywords=[],
+        decorator_list=[])
+    return result

--- a/tests/test_export_pydantic.py
+++ b/tests/test_export_pydantic.py
@@ -12,7 +12,6 @@ def test_simple_model_export():
             "f": spec.Field(
                 type="string")})
     ast_class = conv.generate_model_class("Test", m)
-    print(ast.dump(ast_class))
     assert ast.unparse(ast_class) == dedent(
     """
     class Test(pydantic.BaseModel):
@@ -51,4 +50,66 @@ def test_object_model_export():
             class F(pydantic.BaseModel):
                 f1: str
             f: typing.Optional[F]
+        """).strip()
+
+def test_model_documentation_export():
+    m = spec.Model(
+        description="A test model",
+        fields={
+            "f": spec.Field(
+                type="object",
+                description="A test field",
+                fields={
+                    "f1": spec.Field(
+                        type="string",
+                        required=True)})})
+    ast_class = conv.generate_model_class("Test", m)
+    assert ast.unparse(ast_class) == dedent(
+        """
+        class Test(pydantic.BaseModel):
+            \"""A test model\"""
+
+            class F(pydantic.BaseModel):
+                \"""A test field\"""
+                f1: str
+            f: typing.Optional[F]
+        """).strip()
+
+def test_model_field_description_export():
+    m = spec.Model(
+    fields={
+        "f": spec.Field(
+            type="object",
+            fields={
+                "f1": spec.Field(
+                    type="string",
+                    description="A test field",
+                    required=True)})})
+    ast_class = conv.generate_model_class("Test", m)
+    assert ast.unparse(ast_class) == dedent(
+        """
+        class Test(pydantic.BaseModel):
+
+            class F(pydantic.BaseModel):
+                f1: str
+                'A test field'
+            f: typing.Optional[F]
+        """).strip()
+
+def test_model_description_export():
+    m = spec.DataContractSpecification(
+        info=spec.Info(description="Contract description"),
+        models={"test_model":
+                spec.Model(
+                    fields={
+                        "f": spec.Field(
+                            type="string")})})
+    result = conv.to_pydantic_model_str(m)
+    assert result == dedent(
+        """
+        import datetime, typing, pydantic
+        'Contract description'
+
+        class Test_model(pydantic.BaseModel):
+            f: typing.Optional[str]
         """).strip()

--- a/tests/test_export_pydantic.py
+++ b/tests/test_export_pydantic.py
@@ -1,0 +1,54 @@
+import datacontract.model.data_contract_specification as spec
+import datacontract.export.pydantic_converter as conv
+from textwrap import dedent
+import ast
+
+
+# These tests would be easier if AST nodes were comparable.
+# Current string comparisons are very brittle.
+def test_simple_model_export():
+    m = spec.Model(
+        fields={
+            "f": spec.Field(
+                type="string")})
+    ast_class = conv.generate_model_class("Test", m)
+    print(ast.dump(ast_class))
+    assert ast.unparse(ast_class) == dedent(
+    """
+    class Test(pydantic.BaseModel):
+        f: typing.Optional[str]
+    """).strip()
+
+def test_array_model_export():
+    m = spec.Model(
+        fields={
+            "f": spec.Field(
+                type="array",
+                items=spec.Field(
+                    type="string",
+                    required=True))})
+    ast_class = conv.generate_model_class("Test", m)
+    assert ast.unparse(ast_class) == dedent(
+        """
+        class Test(pydantic.BaseModel):
+            f: typing.Optional[list[str]]
+        """).strip()
+
+def test_object_model_export():
+    m = spec.Model(
+        fields={
+            "f": spec.Field(
+                type="object",
+                fields={
+                    "f1": spec.Field(
+                        type="string",
+                        required=True)})})
+    ast_class = conv.generate_model_class("Test", m)
+    assert ast.unparse(ast_class) == dedent(
+        """
+        class Test(pydantic.BaseModel):
+
+            class F(pydantic.BaseModel):
+                f1: str
+            f: typing.Optional[F]
+        """).strip()


### PR DESCRIPTION
Implements Pydantic model export (#109). Currently missing export of description.
Also replaced uses of print() in `cli.py` with `console.print` to not interpret markup on export.
