### PR TITLE
112 union with null (optional fields)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Added export format **great-expectations**: `datacontract export --format great-expectations`  
 - Added gRPC support to opentelemetry integration for publishing test results
-
+- Added handling for optional fields in avro import #112
 
 ## [0.9.7] - 2024-03-15
 

--- a/tests/examples/avro/data/orders.avsc
+++ b/tests/examples/avro/data/orders.avsc
@@ -14,6 +14,17 @@
         "type": "string"
       },
       {
+        "name": "material",
+        "doc": "An optional field",
+        "type": [
+            "null",
+            {
+                "type": "string",
+                "avro.java.string": "String"
+            }
+        ]
+      },
+      {
         "name": "orderunits",
         "type": "double"
       },

--- a/tests/test_import_avro.py
+++ b/tests/test_import_avro.py
@@ -43,21 +43,33 @@ models:
       ordertime:
         type: long
         description: My Field
+        required: true
       orderid:
         type: int
+        required: true
       itemid:
         type: string
+        required: true
+      material:
+        type: string
+        required: false
+        description: An optional field
       orderunits:
         type: double
+        required: true
       address:
         type: object
+        required: true
         fields:
           city:
             type: string
+            required: true
           state:
             type: string
+            required: true
           zipcode:
             type: long
+            required: true
     """
     print("Result:\n", result.to_yaml())
     assert yaml.safe_load(result.to_yaml()) == yaml.safe_load(expected)


### PR DESCRIPTION
In avro an optional field is represented by a field type union of "null" and the actual type. Such fields are now imported as "required=false" fields in the datacontract, while all other fields are imported as "required=true"