### PR TITLE
added docker-compose.yml and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,30 @@ Or via an alias that automatically uses the latest version:
 alias datacontract='docker run --rm -v "${PWD}:/home/datacontract" datacontract/cli:latest'
 ```
 
+#### Docker compose integration
+
+We've included a [docker-compose.yml](./docker-compose.yml) configuration to simplify the build, test, and deployment of the image.
+
+##### Building the Image with Docker Compose
+
+To build the Docker image using Docker Compose, run the following command:
+
+```bash
+docker compose build
+```
+
+This command utilizes the `docker-compose.yml` to build the image, leveraging predefined settings such as the build context and Dockerfile location. This approach streamlines the image creation process, avoiding the need for manual build specifications each time.
+
+#### Testing the Image
+
+After building the image, you can test it directly with Docker Compose:
+
+```bash
+docker compose run --rm datacontract --version
+```
+
+This command runs the container momentarily to check the version of the `datacontract` CLI. The `--rm` flag ensures that the container is automatically removed after the command executes, keeping your environment clean.
+
 ## Documentation
 
 ### Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+
+services:
+  datacontract:
+    image: datacontract/cli
+    container_name: datacontract    
+    build:
+      context: .
+      dockerfile: Dockerfile 
+    volumes:
+      - .:/home/datacontract:ro
+


### PR DESCRIPTION
A docker-compose.yml with basic specification that hopefully will help others to create the base image locally quicker with just a docker compose build command and being able to execute a docker compose run without the need of writing -v... every time